### PR TITLE
Fix HTTP headers in `fetch` instrumentation

### DIFF
--- a/bin/dd-cucumber-js
+++ b/bin/dd-cucumber-js
@@ -1,14 +1,6 @@
 #!/usr/bin/env node
 
 if (process.env.DD_AGENT_HOST != undefined) {
-    const tracer = require('dd-trace/ci/init');
-    tracer.use('http', {
-        client: {
-            headers: ['x-datadog-trace-id', 'x-datadog-parent-id', 'x-datadog-origin', 'x-datadog-sampling-priority', 'x-datadog-sampled', 'x-datadog-tags']
-        },
-        server: {
-            headers: ['x-datadog-trace-id', 'x-datadog-parent-id', 'x-datadog-origin', 'x-datadog-sampling-priority', 'x-datadog-sampled', 'x-datadog-tags']
-        }
-    })
+    require('dd-trace/ci/init');
 }
 require('@cucumber/cucumber/lib/cli/run.js').default();

--- a/bin/dd-cucumber-js
+++ b/bin/dd-cucumber-js
@@ -1,6 +1,14 @@
 #!/usr/bin/env node
 
 if (process.env.DD_AGENT_HOST != undefined) {
-    require('dd-trace/ci/init');
+    const tracer = require('dd-trace/ci/init');
+    tracer.use('http', {
+        client: {
+            headers: ['x-datadog-trace-id', 'x-datadog-parent-id', 'x-datadog-origin', 'x-datadog-sampling-priority', 'x-datadog-sampled', 'x-datadog-tags']
+        },
+        server: {
+            headers: ['x-datadog-trace-id', 'x-datadog-parent-id', 'x-datadog-origin', 'x-datadog-sampling-priority', 'x-datadog-sampled', 'x-datadog-tags']
+        }
+    })
 }
 require('@cucumber/cucumber/lib/cli/run.js').default();

--- a/features/support/tracer.ts
+++ b/features/support/tracer.ts
@@ -12,7 +12,7 @@ function wrap(method: any) {
     return tracer.trace(
       "fetch",
       { type: "http", resource: request.getUrl() },
-      (span: any, callback) => {
+      (span: any, callback: () => void) => {
         const spanId = span.context().toSpanId();
         const traceId = span.context().toTraceId();
         request.setHeaderParam("x-datadog-parent-id", spanId);

--- a/features/support/tracer.ts
+++ b/features/support/tracer.ts
@@ -12,15 +12,15 @@ function wrap(method: any) {
     return tracer.trace(
       "fetch",
       { type: "http", resource: request.getUrl() },
-      (span: any, callback: ((error?: Error | undefined) => string) | undefined) => {
+      (span: any, callback?: (error?: Error) => string) => {
         const spanId = span.context().toSpanId();
         const traceId = span.context().toTraceId();
         request.setHeaderParam("x-datadog-parent-id", spanId);
         request.setHeaderParam("x-datadog-trace-id", traceId);
         // These headers are required to prevent the continuation of the trace from being dropped
         request.setHeaderParam("x-datadog-origin", "ciapp-test");
-        request.setHeaderParam("x-datadog-sampling-priority", 1);
-        request.setHeaderParam("x-datadog-sampled", 1);
+        request.setHeaderParam("x-datadog-sampling-priority", "1");
+        request.setHeaderParam("x-datadog-sampled", "1");
         const response = method(request);
 
         response.promise = response.promise.then((responseContext: any) => {

--- a/features/support/tracer.ts
+++ b/features/support/tracer.ts
@@ -17,6 +17,7 @@ function wrap(method: any) {
         const traceId = span.context().toTraceId();
         request.setHeaderParam("x-datadog-parent-id", spanId);
         request.setHeaderParam("x-datadog-trace-id", traceId);
+        request.setHeaderParam("x-datadog-origin", 'ciapp-test');
         const response = method(request);
 
         response.promise = response.promise.then((responseContext: any) => {

--- a/features/support/tracer.ts
+++ b/features/support/tracer.ts
@@ -17,7 +17,18 @@ function wrap(method: any) {
         const traceId = span.context().toTraceId();
         request.setHeaderParam("x-datadog-parent-id", spanId);
         request.setHeaderParam("x-datadog-trace-id", traceId);
-        request.setHeaderParam("x-datadog-origin", 'ciapp-test');
+        request.setHeaderParam("x-datadog-origin", "ciapp-test");
+        request.setHeaderParam("x-datadog-sampling-priority", 1);
+        request.setHeaderParam("x-datadog-sampled", 1);
+        span.addTags({
+          "http.headers": JSON.stringify({
+            "x-datadog-parent-id": request.headers["x-datadog-parent-id"],
+            "x-datadog-trace-id": request.headers["x-datadog-trace-id"],
+            "x-datadog-origin": request.headers["x-datadog-origin"],
+            "x-datadog-sampling-priority": request.headers["x-datadog-sampling-priority"],
+            "x-datadog-sampled": request.headers["x-datadog-sampled"],
+          })
+        })
         const response = method(request);
 
         response.promise = response.promise.then((responseContext: any) => {

--- a/features/support/tracer.ts
+++ b/features/support/tracer.ts
@@ -12,7 +12,7 @@ function wrap(method: any) {
     return tracer.trace(
       "fetch",
       { type: "http", resource: request.getUrl() },
-      (span: any) => {
+      (span: any, callback) => {
         const spanId = span.context().toSpanId();
         const traceId = span.context().toTraceId();
         request.setHeaderParam("x-datadog-parent-id", spanId);
@@ -31,9 +31,10 @@ function wrap(method: any) {
               "error.msg": violations,
             });
           }
+          callback()
           return responseContext;
         });
-        return response.promise;
+        return response;
       }
     );
   }

--- a/features/support/tracer.ts
+++ b/features/support/tracer.ts
@@ -17,18 +17,10 @@ function wrap(method: any) {
         const traceId = span.context().toTraceId();
         request.setHeaderParam("x-datadog-parent-id", spanId);
         request.setHeaderParam("x-datadog-trace-id", traceId);
+        // These headers are required to prevent the continuation of the trace from being dropped
         request.setHeaderParam("x-datadog-origin", "ciapp-test");
         request.setHeaderParam("x-datadog-sampling-priority", 1);
         request.setHeaderParam("x-datadog-sampled", 1);
-        span.addTags({
-          "http.headers": JSON.stringify({
-            "x-datadog-parent-id": request.headers["x-datadog-parent-id"],
-            "x-datadog-trace-id": request.headers["x-datadog-trace-id"],
-            "x-datadog-origin": request.headers["x-datadog-origin"],
-            "x-datadog-sampling-priority": request.headers["x-datadog-sampling-priority"],
-            "x-datadog-sampled": request.headers["x-datadog-sampled"],
-          })
-        })
         const response = method(request);
 
         response.promise = response.promise.then((responseContext: any) => {
@@ -41,7 +33,7 @@ function wrap(method: any) {
           }
           return responseContext;
         });
-        return response;
+        return response.promise;
       }
     );
   }

--- a/features/support/tracer.ts
+++ b/features/support/tracer.ts
@@ -31,11 +31,15 @@ function wrap(method: any) {
               "error.msg": violations,
             });
           }
+          return responseContext;
+        });
+
+        response.promise.finally(() => {
           if (callback) {
             callback()
           }
-          return responseContext;
         });
+
         return response;
       }
     );

--- a/features/support/tracer.ts
+++ b/features/support/tracer.ts
@@ -12,7 +12,7 @@ function wrap(method: any) {
     return tracer.trace(
       "fetch",
       { type: "http", resource: request.getUrl() },
-      (span: any, callback: () => void) => {
+      (span: any, callback: ((error?: Error | undefined) => string) | undefined) => {
         const spanId = span.context().toSpanId();
         const traceId = span.context().toTraceId();
         request.setHeaderParam("x-datadog-parent-id", spanId);
@@ -31,7 +31,9 @@ function wrap(method: any) {
               "error.msg": violations,
             });
           }
-          callback()
+          if (callback) {
+            callback()
+          }
           return responseContext;
         });
         return response;


### PR DESCRIPTION
### What does this PR do?

* Fix priority and origin HTTP headers not being set for custom instrumentation of `fetch`. 
* Fix duration of `fetch` spans. 

### Review checklist

Please check relevant items below:


- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.
