### PR TITLE
Handle lack of process variable

### DIFF
--- a/.generator/templates/configuration.mustache
+++ b/.generator/templates/configuration.mustache
@@ -83,7 +83,7 @@ export interface ConfigurationParameters {
  * @param conf partial configuration
  */
 export function createConfiguration(conf: ConfigurationParameters = {}): Configuration {
-    if (process.env.DD_SITE) {
+    if (process !== undefined && process.env.DD_SITE) {
         let serverConf = server1.getConfiguration();
         server1.setVariables({"site": process.env.DD_SITE} as (typeof serverConf));
         for (const op in operationServers) {
@@ -96,7 +96,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
     {{#isApiKey}}
     {{#isKeyInHeader}}
 
-    if (!("{{name}}" in authMethods) && process.env.{{vendorExtensions.x-env-name}}) {
+    if (!("{{name}}" in authMethods) && process !== undefined && process.env.{{vendorExtensions.x-env-name}}) {
         authMethods["{{name}}"] = process.env.{{vendorExtensions.x-env-name}};
     }
     {{/isKeyInHeader}}

--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,6 @@ export * as v2 from "./packages/datadog-api-client-v2";
 import log from "loglevel";
 
 const logger = log.noConflict();
-logger.setLevel(process.env.DEBUG ? logger.levels.DEBUG : logger.levels.INFO);
+logger.setLevel((process !== undefined && process.env.DEBUG) ? logger.levels.DEBUG : logger.levels.INFO);
 
 export { logger };

--- a/packages/datadog-api-client-v1/configuration.ts
+++ b/packages/datadog-api-client-v1/configuration.ts
@@ -91,7 +91,7 @@ export interface ConfigurationParameters {
 export function createConfiguration(
   conf: ConfigurationParameters = {}
 ): Configuration {
-  if (process.env.DD_SITE) {
+  if (process !== undefined && process.env.DD_SITE) {
     const serverConf = server1.getConfiguration();
     server1.setVariables({ site: process.env.DD_SITE } as typeof serverConf);
     for (const op in operationServers) {
@@ -101,11 +101,19 @@ export function createConfiguration(
 
   const authMethods = conf.authMethods || {};
 
-  if (!("apiKeyAuth" in authMethods) && process.env.DD_API_KEY) {
+  if (
+    !("apiKeyAuth" in authMethods) &&
+    process !== undefined &&
+    process.env.DD_API_KEY
+  ) {
     authMethods["apiKeyAuth"] = process.env.DD_API_KEY;
   }
 
-  if (!("appKeyAuth" in authMethods) && process.env.DD_APP_KEY) {
+  if (
+    !("appKeyAuth" in authMethods) &&
+    process !== undefined &&
+    process.env.DD_APP_KEY
+  ) {
     authMethods["appKeyAuth"] = process.env.DD_APP_KEY;
   }
 

--- a/packages/datadog-api-client-v2/configuration.ts
+++ b/packages/datadog-api-client-v2/configuration.ts
@@ -91,7 +91,7 @@ export interface ConfigurationParameters {
 export function createConfiguration(
   conf: ConfigurationParameters = {}
 ): Configuration {
-  if (process.env.DD_SITE) {
+  if (process !== undefined && process.env.DD_SITE) {
     const serverConf = server1.getConfiguration();
     server1.setVariables({ site: process.env.DD_SITE } as typeof serverConf);
     for (const op in operationServers) {
@@ -101,11 +101,19 @@ export function createConfiguration(
 
   const authMethods = conf.authMethods || {};
 
-  if (!("apiKeyAuth" in authMethods) && process.env.DD_API_KEY) {
+  if (
+    !("apiKeyAuth" in authMethods) &&
+    process !== undefined &&
+    process.env.DD_API_KEY
+  ) {
     authMethods["apiKeyAuth"] = process.env.DD_API_KEY;
   }
 
-  if (!("appKeyAuth" in authMethods) && process.env.DD_APP_KEY) {
+  if (
+    !("appKeyAuth" in authMethods) &&
+    process !== undefined &&
+    process.env.DD_APP_KEY
+  ) {
     authMethods["appKeyAuth"] = process.env.DD_APP_KEY;
   }
 


### PR DESCRIPTION
To prepare for non-node environments, let's check if the process
variable exists.