### PR TITLE
Make `typedoc` a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "form-data": "^3.0.0",
     "loglevel": "^1.7.1",
     "pako": "^2.0.4",
-    "typedoc": "^0.22.11",
     "url-parse": "^1.4.3"
   },
   "resolutions": {
@@ -104,6 +103,7 @@
     "prettier": "^2.4.0",
     "ts-jest": "^27.0.4",
     "ts-node": "^9.1.1",
+    "typedoc": "^0.22.11",
     "typescript": "4.5.5"
   },
   "engines": {


### PR DESCRIPTION
### What does this PR do?

This moves `typedoc` from being a dependency to a dev dependency. Typedoc is only used at build time to build the docs, not at runtime, so it shouldn't be included as a dependency. I noticed it because Typedoc has a peer dependency on Typescript which was obviously going to be unmet since typescript is not a runtime dependency.
