### PR TITLE
Export ObjectSerializer

### DIFF
--- a/.generator/templates/index.mustache
+++ b/.generator/templates/index.mustache
@@ -16,3 +16,4 @@ export { {{#operations}}{{#operation}}{{#hasParams}}{{classname}}{{operationIdCa
 export { {{classname}} } from './models/{{{ classFilename }}}';
 {{/model}}
 {{/models}}
+export { ObjectSerializer } from "./models/ObjectSerializer";

--- a/packages/datadog-api-client-v1/index.ts
+++ b/packages/datadog-api-client-v1/index.ts
@@ -999,3 +999,4 @@ export { WidgetTimeWindows } from "./models/WidgetTimeWindows";
 export { WidgetVerticalAlign } from "./models/WidgetVerticalAlign";
 export { WidgetViewMode } from "./models/WidgetViewMode";
 export { WidgetVizType } from "./models/WidgetVizType";
+export { ObjectSerializer } from "./models/ObjectSerializer";

--- a/packages/datadog-api-client-v2/index.ts
+++ b/packages/datadog-api-client-v2/index.ts
@@ -598,3 +598,4 @@ export { UserUpdateData } from "./models/UserUpdateData";
 export { UserUpdateRequest } from "./models/UserUpdateRequest";
 export { UsersResponse } from "./models/UsersResponse";
 export { UsersType } from "./models/UsersType";
+export { ObjectSerializer } from "./models/ObjectSerializer";


### PR DESCRIPTION
Make ObjectSerializer easily accessible outside the library.

Closes #576