### PR TITLE
Remove datadog-ci git-metadata upload

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -53,13 +53,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14
-      - name: Report source code metadata
-        run: |
-          curl -L "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output ./datadog-ci
-          chmod +x "./datadog-ci"
-          ./datadog-ci git-metadata upload
-        env:
-          DATADOG_API_KEY: ${{ secrets.DD_API_KEY }}
       - name: Run integration tests
         run: ./run-tests.sh
         shell: bash


### PR DESCRIPTION
Remove `datadog-ci git-metadata upload` that sends git metadata as it's not required by #source-code-integration anymore.