### PR TITLE
Fix error handling in APIs

### DIFF
--- a/.generator/src/generator/templates/api/api.j2
+++ b/.generator/src/generator/templates/api/api.j2
@@ -182,16 +182,17 @@ export class {{ className }}ResponseProcessor {
       return body;
       {%- else %}
       const bodyText = ObjectSerializer.parse(await response.body.text(), contentType);
+      let body: {{ responseType }};
       try {
-        const body: {{ responseType }} = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "{{ responseType }}"
         ) as {{ responseType }};
-        throw new ApiException<{{ responseType }}>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<{{ responseType }}>(response.httpStatusCode, bodyText);
       } 
+      throw new ApiException<{{ responseType }}>(response.httpStatusCode, body);
       {%- endif %}
       {%- else %}
       {%- if responseCodes[0].startswith("2") %}

--- a/.generator/src/generator/templates/api/exception.j2
+++ b/.generator/src/generator/templates/api/exception.j2
@@ -10,5 +10,8 @@
 export class ApiException<T> extends Error {
   public constructor(public code: number, public body: T) {
     super("HTTP-Code: " + code + "\nMessage: " + JSON.stringify(body));
+    Object.setPrototypeOf(this, ApiException.prototype);
+    this.code = code;
+    this.body = body;
   }
 }

--- a/features/step_definitions/request_steps.ts
+++ b/features/step_definitions/request_steps.ts
@@ -132,7 +132,11 @@ When("the request is sent", async function (this: World) {
       );
     }
   } catch (error) {
-    this.response = error;
+    if (error instanceof datadogApiClient.client.ApiException) {
+      this.response = error.body;
+    } else {
+      this.response = error;
+    }
     logger.debug(error);
     if (this.requestContext === undefined) {
       throw error;
@@ -193,7 +197,11 @@ When("the request with pagination is sent", async function (this: World) {
     }
     this.response = response;
   } catch (error) {
-    this.response = error;
+    if (error instanceof datadogApiClient.client.ApiException) {
+      this.response = error.body;
+    } else {
+      this.response = error;
+    }
     logger.debug(error);
     if (this.requestContext === undefined) {
       throw error;

--- a/packages/datadog-api-client-common/exception.ts
+++ b/packages/datadog-api-client-common/exception.ts
@@ -10,5 +10,8 @@
 export class ApiException<T> extends Error {
   public constructor(public code: number, public body: T) {
     super("HTTP-Code: " + code + "\nMessage: " + JSON.stringify(body));
+    Object.setPrototypeOf(this, ApiException.prototype);
+    this.code = code;
+    this.body = body;
   }
 }

--- a/packages/datadog-api-client-v1/apis/AWSIntegrationApi.ts
+++ b/packages/datadog-api-client-v1/apis/AWSIntegrationApi.ts
@@ -460,12 +460,12 @@ export class AWSIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -473,6 +473,7 @@ export class AWSIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -519,12 +520,12 @@ export class AWSIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -532,6 +533,7 @@ export class AWSIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -580,12 +582,12 @@ export class AWSIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -593,6 +595,7 @@ export class AWSIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -640,12 +643,12 @@ export class AWSIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -653,6 +656,7 @@ export class AWSIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -699,12 +703,12 @@ export class AWSIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -712,6 +716,7 @@ export class AWSIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -756,12 +761,12 @@ export class AWSIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -769,6 +774,7 @@ export class AWSIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -817,12 +823,12 @@ export class AWSIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -830,6 +836,7 @@ export class AWSIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -878,12 +885,12 @@ export class AWSIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -891,6 +898,7 @@ export class AWSIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -938,12 +946,12 @@ export class AWSIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -951,6 +959,7 @@ export class AWSIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/AWSLogsIntegrationApi.ts
+++ b/packages/datadog-api-client-v1/apis/AWSLogsIntegrationApi.ts
@@ -327,12 +327,12 @@ export class AWSLogsIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -340,6 +340,7 @@ export class AWSLogsIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -388,12 +389,12 @@ export class AWSLogsIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -401,6 +402,7 @@ export class AWSLogsIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -447,12 +449,12 @@ export class AWSLogsIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -460,6 +462,7 @@ export class AWSLogsIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -506,12 +509,12 @@ export class AWSLogsIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -519,6 +522,7 @@ export class AWSLogsIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -565,12 +569,12 @@ export class AWSLogsIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -578,6 +582,7 @@ export class AWSLogsIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -626,12 +631,12 @@ export class AWSLogsIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -639,6 +644,7 @@ export class AWSLogsIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -684,12 +690,12 @@ export class AWSLogsIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -697,6 +703,7 @@ export class AWSLogsIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/AuthenticationApi.ts
+++ b/packages/datadog-api-client-v1/apis/AuthenticationApi.ts
@@ -69,12 +69,12 @@ export class AuthenticationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -82,6 +82,7 @@ export class AuthenticationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/AzureIntegrationApi.ts
+++ b/packages/datadog-api-client-v1/apis/AzureIntegrationApi.ts
@@ -251,12 +251,12 @@ export class AzureIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -264,6 +264,7 @@ export class AzureIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -310,12 +311,12 @@ export class AzureIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -323,6 +324,7 @@ export class AzureIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -371,12 +373,12 @@ export class AzureIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -384,6 +386,7 @@ export class AzureIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -430,12 +433,12 @@ export class AzureIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -443,6 +446,7 @@ export class AzureIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -489,12 +493,12 @@ export class AzureIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -502,6 +506,7 @@ export class AzureIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/DashboardListsApi.ts
+++ b/packages/datadog-api-client-v1/apis/DashboardListsApi.ts
@@ -255,12 +255,12 @@ export class DashboardListsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -268,6 +268,7 @@ export class DashboardListsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -316,12 +317,12 @@ export class DashboardListsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -329,6 +330,7 @@ export class DashboardListsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -377,12 +379,12 @@ export class DashboardListsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -390,6 +392,7 @@ export class DashboardListsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -434,12 +437,12 @@ export class DashboardListsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -447,6 +450,7 @@ export class DashboardListsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -496,12 +500,12 @@ export class DashboardListsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -509,6 +513,7 @@ export class DashboardListsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/DashboardsApi.ts
+++ b/packages/datadog-api-client-v1/apis/DashboardsApi.ts
@@ -361,12 +361,12 @@ export class DashboardsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -374,6 +374,7 @@ export class DashboardsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -422,12 +423,12 @@ export class DashboardsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -435,6 +436,7 @@ export class DashboardsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -478,12 +480,12 @@ export class DashboardsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -491,6 +493,7 @@ export class DashboardsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -537,12 +540,12 @@ export class DashboardsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -550,6 +553,7 @@ export class DashboardsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -594,12 +598,12 @@ export class DashboardsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -607,6 +611,7 @@ export class DashboardsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -650,12 +655,12 @@ export class DashboardsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -663,6 +668,7 @@ export class DashboardsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -710,12 +716,12 @@ export class DashboardsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -723,6 +729,7 @@ export class DashboardsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/DowntimesApi.ts
+++ b/packages/datadog-api-client-v1/apis/DowntimesApi.ts
@@ -340,12 +340,12 @@ export class DowntimesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -353,6 +353,7 @@ export class DowntimesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -402,12 +403,12 @@ export class DowntimesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -415,6 +416,7 @@ export class DowntimesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -461,12 +463,12 @@ export class DowntimesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -474,6 +476,7 @@ export class DowntimesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -520,12 +523,12 @@ export class DowntimesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -533,6 +536,7 @@ export class DowntimesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -577,12 +581,12 @@ export class DowntimesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -590,6 +594,7 @@ export class DowntimesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -638,12 +643,12 @@ export class DowntimesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -651,6 +656,7 @@ export class DowntimesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -698,12 +704,12 @@ export class DowntimesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -711,6 +717,7 @@ export class DowntimesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/EventsApi.ts
+++ b/packages/datadog-api-client-v1/apis/EventsApi.ts
@@ -228,12 +228,12 @@ export class EventsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -241,6 +241,7 @@ export class EventsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -287,12 +288,12 @@ export class EventsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -300,6 +301,7 @@ export class EventsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -348,12 +350,12 @@ export class EventsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -361,6 +363,7 @@ export class EventsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/GCPIntegrationApi.ts
+++ b/packages/datadog-api-client-v1/apis/GCPIntegrationApi.ts
@@ -207,12 +207,12 @@ export class GCPIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -220,6 +220,7 @@ export class GCPIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -266,12 +267,12 @@ export class GCPIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -279,6 +280,7 @@ export class GCPIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -327,12 +329,12 @@ export class GCPIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -340,6 +342,7 @@ export class GCPIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -386,12 +389,12 @@ export class GCPIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -399,6 +402,7 @@ export class GCPIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/HostsApi.ts
+++ b/packages/datadog-api-client-v1/apis/HostsApi.ts
@@ -263,12 +263,12 @@ export class HostsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -276,6 +276,7 @@ export class HostsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -322,12 +323,12 @@ export class HostsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -335,6 +336,7 @@ export class HostsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -381,12 +383,12 @@ export class HostsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -394,6 +396,7 @@ export class HostsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -442,12 +445,12 @@ export class HostsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -455,6 +458,7 @@ export class HostsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/IPRangesApi.ts
+++ b/packages/datadog-api-client-v1/apis/IPRangesApi.ts
@@ -59,12 +59,12 @@ export class IPRangesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -72,6 +72,7 @@ export class IPRangesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/KeyManagementApi.ts
+++ b/packages/datadog-api-client-v1/apis/KeyManagementApi.ts
@@ -447,12 +447,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -460,6 +460,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -509,12 +510,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -522,6 +523,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -571,12 +573,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -584,6 +586,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -632,12 +635,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -645,6 +648,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -691,12 +695,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -704,6 +708,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -752,12 +757,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -765,6 +770,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -809,12 +815,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -822,6 +828,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -866,12 +873,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -879,6 +886,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -928,12 +936,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -941,6 +949,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -991,12 +1000,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1004,6 +1013,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/LogsApi.ts
+++ b/packages/datadog-api-client-v1/apis/LogsApi.ts
@@ -157,15 +157,12 @@ export class LogsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: LogsAPIErrorResponse;
       try {
-        const body: LogsAPIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "LogsAPIErrorResponse"
         ) as LogsAPIErrorResponse;
-        throw new ApiException<LogsAPIErrorResponse>(
-          response.httpStatusCode,
-          body
-        );
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<LogsAPIErrorResponse>(
@@ -173,18 +170,22 @@ export class LogsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<LogsAPIErrorResponse>(
+        response.httpStatusCode,
+        body
+      );
     }
     if (response.httpStatusCode == 403 || response.httpStatusCode == 429) {
       const bodyText = ObjectSerializer.parse(
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -192,6 +193,7 @@ export class LogsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -234,28 +236,29 @@ export class LogsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: HTTPLogError;
       try {
-        const body: HTTPLogError = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "HTTPLogError"
         ) as HTTPLogError;
-        throw new ApiException<HTTPLogError>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<HTTPLogError>(response.httpStatusCode, bodyText);
       }
+      throw new ApiException<HTTPLogError>(response.httpStatusCode, body);
     }
     if (response.httpStatusCode == 429) {
       const bodyText = ObjectSerializer.parse(
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -263,6 +266,7 @@ export class LogsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/LogsIndexesApi.ts
+++ b/packages/datadog-api-client-v1/apis/LogsIndexesApi.ts
@@ -281,15 +281,12 @@ export class LogsIndexesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: LogsAPIErrorResponse;
       try {
-        const body: LogsAPIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "LogsAPIErrorResponse"
         ) as LogsAPIErrorResponse;
-        throw new ApiException<LogsAPIErrorResponse>(
-          response.httpStatusCode,
-          body
-        );
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<LogsAPIErrorResponse>(
@@ -297,18 +294,22 @@ export class LogsIndexesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<LogsAPIErrorResponse>(
+        response.httpStatusCode,
+        body
+      );
     }
     if (response.httpStatusCode == 403 || response.httpStatusCode == 429) {
       const bodyText = ObjectSerializer.parse(
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -316,6 +317,7 @@ export class LogsIndexesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -358,12 +360,12 @@ export class LogsIndexesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -371,21 +373,19 @@ export class LogsIndexesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
     if (response.httpStatusCode == 404) {
       const bodyText = ObjectSerializer.parse(
         await response.body.text(),
         contentType
       );
+      let body: LogsAPIErrorResponse;
       try {
-        const body: LogsAPIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "LogsAPIErrorResponse"
         ) as LogsAPIErrorResponse;
-        throw new ApiException<LogsAPIErrorResponse>(
-          response.httpStatusCode,
-          body
-        );
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<LogsAPIErrorResponse>(
@@ -393,6 +393,10 @@ export class LogsIndexesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<LogsAPIErrorResponse>(
+        response.httpStatusCode,
+        body
+      );
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -437,12 +441,12 @@ export class LogsIndexesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -450,6 +454,7 @@ export class LogsIndexesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -494,12 +499,12 @@ export class LogsIndexesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -507,6 +512,7 @@ export class LogsIndexesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -549,15 +555,12 @@ export class LogsIndexesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: LogsAPIErrorResponse;
       try {
-        const body: LogsAPIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "LogsAPIErrorResponse"
         ) as LogsAPIErrorResponse;
-        throw new ApiException<LogsAPIErrorResponse>(
-          response.httpStatusCode,
-          body
-        );
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<LogsAPIErrorResponse>(
@@ -565,18 +568,22 @@ export class LogsIndexesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<LogsAPIErrorResponse>(
+        response.httpStatusCode,
+        body
+      );
     }
     if (response.httpStatusCode == 403) {
       const bodyText = ObjectSerializer.parse(
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -584,6 +591,7 @@ export class LogsIndexesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -628,15 +636,12 @@ export class LogsIndexesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: LogsAPIErrorResponse;
       try {
-        const body: LogsAPIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "LogsAPIErrorResponse"
         ) as LogsAPIErrorResponse;
-        throw new ApiException<LogsAPIErrorResponse>(
-          response.httpStatusCode,
-          body
-        );
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<LogsAPIErrorResponse>(
@@ -644,18 +649,22 @@ export class LogsIndexesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<LogsAPIErrorResponse>(
+        response.httpStatusCode,
+        body
+      );
     }
     if (response.httpStatusCode == 403 || response.httpStatusCode == 429) {
       const bodyText = ObjectSerializer.parse(
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -663,6 +672,7 @@ export class LogsIndexesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/LogsPipelinesApi.ts
+++ b/packages/datadog-api-client-v1/apis/LogsPipelinesApi.ts
@@ -318,15 +318,12 @@ export class LogsPipelinesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: LogsAPIErrorResponse;
       try {
-        const body: LogsAPIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "LogsAPIErrorResponse"
         ) as LogsAPIErrorResponse;
-        throw new ApiException<LogsAPIErrorResponse>(
-          response.httpStatusCode,
-          body
-        );
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<LogsAPIErrorResponse>(
@@ -334,18 +331,22 @@ export class LogsPipelinesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<LogsAPIErrorResponse>(
+        response.httpStatusCode,
+        body
+      );
     }
     if (response.httpStatusCode == 403 || response.httpStatusCode == 429) {
       const bodyText = ObjectSerializer.parse(
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -353,6 +354,7 @@ export class LogsPipelinesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -391,15 +393,12 @@ export class LogsPipelinesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: LogsAPIErrorResponse;
       try {
-        const body: LogsAPIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "LogsAPIErrorResponse"
         ) as LogsAPIErrorResponse;
-        throw new ApiException<LogsAPIErrorResponse>(
-          response.httpStatusCode,
-          body
-        );
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<LogsAPIErrorResponse>(
@@ -407,18 +406,22 @@ export class LogsPipelinesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<LogsAPIErrorResponse>(
+        response.httpStatusCode,
+        body
+      );
     }
     if (response.httpStatusCode == 403 || response.httpStatusCode == 429) {
       const bodyText = ObjectSerializer.parse(
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -426,6 +429,7 @@ export class LogsPipelinesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -470,15 +474,12 @@ export class LogsPipelinesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: LogsAPIErrorResponse;
       try {
-        const body: LogsAPIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "LogsAPIErrorResponse"
         ) as LogsAPIErrorResponse;
-        throw new ApiException<LogsAPIErrorResponse>(
-          response.httpStatusCode,
-          body
-        );
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<LogsAPIErrorResponse>(
@@ -486,18 +487,22 @@ export class LogsPipelinesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<LogsAPIErrorResponse>(
+        response.httpStatusCode,
+        body
+      );
     }
     if (response.httpStatusCode == 403 || response.httpStatusCode == 429) {
       const bodyText = ObjectSerializer.parse(
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -505,6 +510,7 @@ export class LogsPipelinesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -549,12 +555,12 @@ export class LogsPipelinesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -562,6 +568,7 @@ export class LogsPipelinesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -606,12 +613,12 @@ export class LogsPipelinesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -619,6 +626,7 @@ export class LogsPipelinesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -663,15 +671,12 @@ export class LogsPipelinesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: LogsAPIErrorResponse;
       try {
-        const body: LogsAPIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "LogsAPIErrorResponse"
         ) as LogsAPIErrorResponse;
-        throw new ApiException<LogsAPIErrorResponse>(
-          response.httpStatusCode,
-          body
-        );
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<LogsAPIErrorResponse>(
@@ -679,18 +684,22 @@ export class LogsPipelinesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<LogsAPIErrorResponse>(
+        response.httpStatusCode,
+        body
+      );
     }
     if (response.httpStatusCode == 403 || response.httpStatusCode == 429) {
       const bodyText = ObjectSerializer.parse(
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -698,6 +707,7 @@ export class LogsPipelinesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -742,15 +752,12 @@ export class LogsPipelinesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: LogsAPIErrorResponse;
       try {
-        const body: LogsAPIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "LogsAPIErrorResponse"
         ) as LogsAPIErrorResponse;
-        throw new ApiException<LogsAPIErrorResponse>(
-          response.httpStatusCode,
-          body
-        );
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<LogsAPIErrorResponse>(
@@ -758,18 +765,22 @@ export class LogsPipelinesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<LogsAPIErrorResponse>(
+        response.httpStatusCode,
+        body
+      );
     }
     if (response.httpStatusCode == 403 || response.httpStatusCode == 429) {
       const bodyText = ObjectSerializer.parse(
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -777,6 +788,7 @@ export class LogsPipelinesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/MetricsApi.ts
+++ b/packages/datadog-api-client-v1/apis/MetricsApi.ts
@@ -420,12 +420,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -433,6 +433,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -481,12 +482,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -494,6 +495,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -542,12 +544,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -555,6 +557,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -603,12 +606,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -616,6 +619,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -666,12 +670,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -679,6 +683,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -729,12 +734,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -742,6 +747,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -791,12 +797,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -804,6 +810,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/MonitorsApi.ts
+++ b/packages/datadog-api-client-v1/apis/MonitorsApi.ts
@@ -589,12 +589,12 @@ export class MonitorsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -602,6 +602,7 @@ export class MonitorsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -648,12 +649,12 @@ export class MonitorsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -661,6 +662,7 @@ export class MonitorsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -711,12 +713,12 @@ export class MonitorsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -724,6 +726,7 @@ export class MonitorsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -771,12 +774,12 @@ export class MonitorsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -784,6 +787,7 @@ export class MonitorsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -832,12 +836,12 @@ export class MonitorsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -845,6 +849,7 @@ export class MonitorsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -893,12 +898,12 @@ export class MonitorsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -906,6 +911,7 @@ export class MonitorsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -954,12 +960,12 @@ export class MonitorsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -967,6 +973,7 @@ export class MonitorsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1015,12 +1022,12 @@ export class MonitorsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1028,6 +1035,7 @@ export class MonitorsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1076,12 +1084,12 @@ export class MonitorsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1089,6 +1097,7 @@ export class MonitorsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1135,12 +1144,12 @@ export class MonitorsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1148,6 +1157,7 @@ export class MonitorsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/NotebooksApi.ts
+++ b/packages/datadog-api-client-v1/apis/NotebooksApi.ts
@@ -323,12 +323,12 @@ export class NotebooksApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -336,6 +336,7 @@ export class NotebooksApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -379,12 +380,12 @@ export class NotebooksApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -392,6 +393,7 @@ export class NotebooksApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -441,12 +443,12 @@ export class NotebooksApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -454,6 +456,7 @@ export class NotebooksApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -502,12 +505,12 @@ export class NotebooksApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -515,6 +518,7 @@ export class NotebooksApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -565,12 +569,12 @@ export class NotebooksApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -578,6 +582,7 @@ export class NotebooksApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/OrganizationsApi.ts
+++ b/packages/datadog-api-client-v1/apis/OrganizationsApi.ts
@@ -307,12 +307,12 @@ export class OrganizationsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -320,6 +320,7 @@ export class OrganizationsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -368,12 +369,12 @@ export class OrganizationsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -381,6 +382,7 @@ export class OrganizationsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -429,12 +431,12 @@ export class OrganizationsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -442,6 +444,7 @@ export class OrganizationsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -486,12 +489,12 @@ export class OrganizationsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -499,6 +502,7 @@ export class OrganizationsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -547,12 +551,12 @@ export class OrganizationsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -560,6 +564,7 @@ export class OrganizationsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -609,12 +614,12 @@ export class OrganizationsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -622,6 +627,7 @@ export class OrganizationsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/PagerDutyIntegrationApi.ts
+++ b/packages/datadog-api-client-v1/apis/PagerDutyIntegrationApi.ts
@@ -228,12 +228,12 @@ export class PagerDutyIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -241,6 +241,7 @@ export class PagerDutyIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -285,12 +286,12 @@ export class PagerDutyIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -298,6 +299,7 @@ export class PagerDutyIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -346,12 +348,12 @@ export class PagerDutyIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -359,6 +361,7 @@ export class PagerDutyIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -404,12 +407,12 @@ export class PagerDutyIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -417,6 +420,7 @@ export class PagerDutyIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/SecurityMonitoringApi.ts
+++ b/packages/datadog-api-client-v1/apis/SecurityMonitoringApi.ts
@@ -224,12 +224,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -237,6 +237,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -286,12 +287,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -299,6 +300,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -348,12 +350,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -361,6 +363,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/ServiceChecksApi.ts
+++ b/packages/datadog-api-client-v1/apis/ServiceChecksApi.ts
@@ -96,12 +96,12 @@ export class ServiceChecksApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -109,6 +109,7 @@ export class ServiceChecksApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/ServiceLevelObjectiveCorrectionsApi.ts
+++ b/packages/datadog-api-client-v1/apis/ServiceLevelObjectiveCorrectionsApi.ts
@@ -252,12 +252,12 @@ export class ServiceLevelObjectiveCorrectionsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -265,6 +265,7 @@ export class ServiceLevelObjectiveCorrectionsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -307,12 +308,12 @@ export class ServiceLevelObjectiveCorrectionsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -320,6 +321,7 @@ export class ServiceLevelObjectiveCorrectionsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -368,12 +370,12 @@ export class ServiceLevelObjectiveCorrectionsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -381,6 +383,7 @@ export class ServiceLevelObjectiveCorrectionsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -425,12 +428,12 @@ export class ServiceLevelObjectiveCorrectionsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -438,6 +441,7 @@ export class ServiceLevelObjectiveCorrectionsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -487,12 +491,12 @@ export class ServiceLevelObjectiveCorrectionsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -500,6 +504,7 @@ export class ServiceLevelObjectiveCorrectionsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/ServiceLevelObjectivesApi.ts
+++ b/packages/datadog-api-client-v1/apis/ServiceLevelObjectivesApi.ts
@@ -590,12 +590,12 @@ export class ServiceLevelObjectivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -603,6 +603,7 @@ export class ServiceLevelObjectivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -649,12 +650,12 @@ export class ServiceLevelObjectivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -662,6 +663,7 @@ export class ServiceLevelObjectivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -710,12 +712,12 @@ export class ServiceLevelObjectivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -723,6 +725,7 @@ export class ServiceLevelObjectivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -771,12 +774,12 @@ export class ServiceLevelObjectivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -784,6 +787,7 @@ export class ServiceLevelObjectivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -830,12 +834,12 @@ export class ServiceLevelObjectivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -843,6 +847,7 @@ export class ServiceLevelObjectivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -892,12 +897,12 @@ export class ServiceLevelObjectivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -905,6 +910,7 @@ export class ServiceLevelObjectivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -954,12 +960,12 @@ export class ServiceLevelObjectivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -967,6 +973,7 @@ export class ServiceLevelObjectivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1014,12 +1021,12 @@ export class ServiceLevelObjectivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1027,6 +1034,7 @@ export class ServiceLevelObjectivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1075,12 +1083,12 @@ export class ServiceLevelObjectivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1088,6 +1096,7 @@ export class ServiceLevelObjectivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1135,12 +1144,12 @@ export class ServiceLevelObjectivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1148,6 +1157,7 @@ export class ServiceLevelObjectivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/SlackIntegrationApi.ts
+++ b/packages/datadog-api-client-v1/apis/SlackIntegrationApi.ts
@@ -315,12 +315,12 @@ export class SlackIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -328,6 +328,7 @@ export class SlackIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -377,12 +378,12 @@ export class SlackIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -390,6 +391,7 @@ export class SlackIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -439,12 +441,12 @@ export class SlackIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -452,6 +454,7 @@ export class SlackIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -497,12 +500,12 @@ export class SlackIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -510,6 +513,7 @@ export class SlackIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -559,12 +563,12 @@ export class SlackIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -572,6 +576,7 @@ export class SlackIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/SnapshotsApi.ts
+++ b/packages/datadog-api-client-v1/apis/SnapshotsApi.ts
@@ -150,12 +150,12 @@ export class SnapshotsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -163,6 +163,7 @@ export class SnapshotsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/SyntheticsApi.ts
+++ b/packages/datadog-api-client-v1/apis/SyntheticsApi.ts
@@ -1256,12 +1256,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1269,6 +1269,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1318,12 +1319,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1331,6 +1332,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1381,12 +1383,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1394,6 +1396,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1443,12 +1446,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1456,6 +1459,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1499,12 +1503,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1512,6 +1516,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1550,12 +1555,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1563,6 +1568,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1612,12 +1618,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1625,6 +1631,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1673,12 +1680,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1686,6 +1693,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1734,12 +1742,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1747,6 +1755,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1796,12 +1805,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1809,6 +1818,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1858,12 +1868,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1871,6 +1881,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1919,12 +1930,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1932,6 +1943,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1981,12 +1993,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1994,6 +2006,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2044,12 +2057,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2057,6 +2070,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2106,12 +2120,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2119,6 +2133,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2163,12 +2178,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2176,6 +2191,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2220,12 +2236,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2233,6 +2249,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2281,12 +2298,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2294,6 +2311,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2339,12 +2357,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2352,6 +2370,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2397,12 +2416,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2410,6 +2429,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2458,12 +2478,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2471,6 +2491,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2516,12 +2537,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2529,6 +2550,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2575,12 +2597,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2588,6 +2610,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2638,12 +2661,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2651,6 +2674,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2700,12 +2724,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2713,6 +2737,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2757,12 +2782,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2770,6 +2795,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2819,12 +2845,12 @@ export class SyntheticsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2832,6 +2858,7 @@ export class SyntheticsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/TagsApi.ts
+++ b/packages/datadog-api-client-v1/apis/TagsApi.ts
@@ -304,12 +304,12 @@ export class TagsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -317,6 +317,7 @@ export class TagsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -359,12 +360,12 @@ export class TagsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -372,6 +373,7 @@ export class TagsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -418,12 +420,12 @@ export class TagsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -431,6 +433,7 @@ export class TagsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -477,12 +480,12 @@ export class TagsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -490,6 +493,7 @@ export class TagsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -536,12 +540,12 @@ export class TagsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -549,6 +553,7 @@ export class TagsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/UsageMeteringApi.ts
+++ b/packages/datadog-api-client-v1/apis/UsageMeteringApi.ts
@@ -2225,12 +2225,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2238,6 +2238,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2282,12 +2283,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2295,6 +2296,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2344,12 +2346,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2357,6 +2359,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2406,12 +2409,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2419,6 +2422,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2463,12 +2467,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2476,6 +2480,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2521,12 +2526,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2534,6 +2539,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2584,12 +2590,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2597,6 +2603,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2648,12 +2655,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2661,6 +2668,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2710,12 +2718,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2723,6 +2731,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2767,12 +2776,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2780,6 +2789,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2828,12 +2838,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2841,6 +2851,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2889,12 +2900,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2902,6 +2913,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -2950,12 +2962,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -2963,6 +2975,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3012,12 +3025,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -3025,6 +3038,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3074,12 +3088,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -3087,6 +3101,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3135,12 +3150,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -3148,6 +3163,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3196,12 +3212,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -3209,6 +3225,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3257,12 +3274,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -3270,6 +3287,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3318,12 +3336,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -3331,6 +3349,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3379,12 +3398,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -3392,6 +3411,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3440,12 +3460,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -3453,6 +3473,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3501,12 +3522,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -3514,6 +3535,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3562,12 +3584,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -3575,6 +3597,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3623,12 +3646,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -3636,6 +3659,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3684,12 +3708,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -3697,6 +3721,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3745,12 +3770,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -3758,6 +3783,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3806,12 +3832,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -3819,6 +3845,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3867,12 +3894,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -3880,6 +3907,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3928,12 +3956,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -3941,6 +3969,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -3989,12 +4018,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -4002,6 +4031,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -4050,12 +4080,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -4063,6 +4093,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -4111,12 +4142,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -4124,6 +4155,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -4172,12 +4204,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -4185,6 +4217,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -4233,12 +4266,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -4246,6 +4279,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -4294,12 +4328,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -4307,6 +4341,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -4355,12 +4390,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -4368,6 +4403,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -4416,12 +4452,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -4429,6 +4465,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -4477,12 +4514,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -4490,6 +4527,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/UsersApi.ts
+++ b/packages/datadog-api-client-v1/apis/UsersApi.ts
@@ -250,12 +250,12 @@ export class UsersApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -263,6 +263,7 @@ export class UsersApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -312,12 +313,12 @@ export class UsersApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -325,6 +326,7 @@ export class UsersApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -371,12 +373,12 @@ export class UsersApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -384,6 +386,7 @@ export class UsersApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -426,12 +429,12 @@ export class UsersApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -439,6 +442,7 @@ export class UsersApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -486,12 +490,12 @@ export class UsersApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -499,6 +503,7 @@ export class UsersApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v1/apis/WebhooksIntegrationApi.ts
+++ b/packages/datadog-api-client-v1/apis/WebhooksIntegrationApi.ts
@@ -409,12 +409,12 @@ export class WebhooksIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -422,6 +422,7 @@ export class WebhooksIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -471,12 +472,12 @@ export class WebhooksIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -484,6 +485,7 @@ export class WebhooksIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -529,12 +531,12 @@ export class WebhooksIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -542,6 +544,7 @@ export class WebhooksIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -586,12 +589,12 @@ export class WebhooksIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -599,6 +602,7 @@ export class WebhooksIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -648,12 +652,12 @@ export class WebhooksIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -661,6 +665,7 @@ export class WebhooksIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -711,12 +716,12 @@ export class WebhooksIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -724,6 +729,7 @@ export class WebhooksIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -774,12 +780,12 @@ export class WebhooksIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -787,6 +793,7 @@ export class WebhooksIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -837,12 +844,12 @@ export class WebhooksIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -850,6 +857,7 @@ export class WebhooksIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/AuditApi.ts
+++ b/packages/datadog-api-client-v2/apis/AuditApi.ts
@@ -159,12 +159,12 @@ export class AuditApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -172,6 +172,7 @@ export class AuditApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -220,12 +221,12 @@ export class AuditApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -233,6 +234,7 @@ export class AuditApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/AuthNMappingsApi.ts
+++ b/packages/datadog-api-client-v2/apis/AuthNMappingsApi.ts
@@ -288,12 +288,12 @@ export class AuthNMappingsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -301,6 +301,7 @@ export class AuthNMappingsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -343,12 +344,12 @@ export class AuthNMappingsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -356,6 +357,7 @@ export class AuthNMappingsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -404,12 +406,12 @@ export class AuthNMappingsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -417,6 +419,7 @@ export class AuthNMappingsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -461,12 +464,12 @@ export class AuthNMappingsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -474,6 +477,7 @@ export class AuthNMappingsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -525,12 +529,12 @@ export class AuthNMappingsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -538,6 +542,7 @@ export class AuthNMappingsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/CloudWorkloadSecurityApi.ts
+++ b/packages/datadog-api-client-v2/apis/CloudWorkloadSecurityApi.ts
@@ -295,12 +295,12 @@ export class CloudWorkloadSecurityApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -308,6 +308,7 @@ export class CloudWorkloadSecurityApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -353,12 +354,12 @@ export class CloudWorkloadSecurityApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -366,6 +367,7 @@ export class CloudWorkloadSecurityApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -407,12 +409,12 @@ export class CloudWorkloadSecurityApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -420,6 +422,7 @@ export class CloudWorkloadSecurityApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -466,12 +469,12 @@ export class CloudWorkloadSecurityApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -479,6 +482,7 @@ export class CloudWorkloadSecurityApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -525,12 +529,12 @@ export class CloudWorkloadSecurityApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -538,6 +542,7 @@ export class CloudWorkloadSecurityApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -590,12 +595,12 @@ export class CloudWorkloadSecurityApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -603,6 +608,7 @@ export class CloudWorkloadSecurityApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/DashboardListsApi.ts
+++ b/packages/datadog-api-client-v2/apis/DashboardListsApi.ts
@@ -265,12 +265,12 @@ export class DashboardListsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -278,6 +278,7 @@ export class DashboardListsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -328,12 +329,12 @@ export class DashboardListsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -341,6 +342,7 @@ export class DashboardListsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -390,12 +392,12 @@ export class DashboardListsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -403,6 +405,7 @@ export class DashboardListsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -453,12 +456,12 @@ export class DashboardListsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -466,6 +469,7 @@ export class DashboardListsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/EventsApi.ts
+++ b/packages/datadog-api-client-v2/apis/EventsApi.ts
@@ -171,12 +171,12 @@ export class EventsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -184,6 +184,7 @@ export class EventsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -232,12 +233,12 @@ export class EventsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -245,6 +246,7 @@ export class EventsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/IncidentServicesApi.ts
+++ b/packages/datadog-api-client-v2/apis/IncidentServicesApi.ts
@@ -323,12 +323,12 @@ export class IncidentServicesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -336,6 +336,7 @@ export class IncidentServicesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -380,12 +381,12 @@ export class IncidentServicesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -393,6 +394,7 @@ export class IncidentServicesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -443,12 +445,12 @@ export class IncidentServicesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -456,6 +458,7 @@ export class IncidentServicesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -506,12 +509,12 @@ export class IncidentServicesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -519,6 +522,7 @@ export class IncidentServicesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -569,12 +573,12 @@ export class IncidentServicesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -582,6 +586,7 @@ export class IncidentServicesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/IncidentTeamsApi.ts
+++ b/packages/datadog-api-client-v2/apis/IncidentTeamsApi.ts
@@ -323,12 +323,12 @@ export class IncidentTeamsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -336,6 +336,7 @@ export class IncidentTeamsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -380,12 +381,12 @@ export class IncidentTeamsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -393,6 +394,7 @@ export class IncidentTeamsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -443,12 +445,12 @@ export class IncidentTeamsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -456,6 +458,7 @@ export class IncidentTeamsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -506,12 +509,12 @@ export class IncidentTeamsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -519,6 +522,7 @@ export class IncidentTeamsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -569,12 +573,12 @@ export class IncidentTeamsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -582,6 +586,7 @@ export class IncidentTeamsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/IncidentsApi.ts
+++ b/packages/datadog-api-client-v2/apis/IncidentsApi.ts
@@ -474,12 +474,12 @@ export class IncidentsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -487,6 +487,7 @@ export class IncidentsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -531,12 +532,12 @@ export class IncidentsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -544,6 +545,7 @@ export class IncidentsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -594,12 +596,12 @@ export class IncidentsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -607,6 +609,7 @@ export class IncidentsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -657,12 +660,12 @@ export class IncidentsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -670,6 +673,7 @@ export class IncidentsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -720,12 +724,12 @@ export class IncidentsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -733,6 +737,7 @@ export class IncidentsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -783,12 +788,12 @@ export class IncidentsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -796,6 +801,7 @@ export class IncidentsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -847,12 +853,12 @@ export class IncidentsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -860,6 +866,7 @@ export class IncidentsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/KeyManagementApi.ts
+++ b/packages/datadog-api-client-v2/apis/KeyManagementApi.ts
@@ -779,12 +779,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -792,6 +792,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -840,12 +841,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -853,6 +854,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -895,12 +897,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -908,6 +910,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -950,12 +953,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -963,6 +966,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1007,12 +1011,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1020,6 +1024,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1066,12 +1071,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1079,6 +1084,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1128,12 +1134,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1141,6 +1147,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1189,12 +1196,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1202,6 +1209,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1250,12 +1258,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1263,6 +1271,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1312,12 +1321,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1325,6 +1334,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1374,12 +1384,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1387,6 +1397,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1436,12 +1447,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1449,6 +1460,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1498,12 +1510,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1511,6 +1523,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1560,12 +1573,12 @@ export class KeyManagementApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1573,6 +1586,7 @@ export class KeyManagementApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/LogsApi.ts
+++ b/packages/datadog-api-client-v2/apis/LogsApi.ts
@@ -279,12 +279,12 @@ export class LogsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -292,6 +292,7 @@ export class LogsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -338,12 +339,12 @@ export class LogsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -351,6 +352,7 @@ export class LogsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -399,12 +401,12 @@ export class LogsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -412,6 +414,7 @@ export class LogsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -463,12 +466,12 @@ export class LogsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: HTTPLogErrors;
       try {
-        const body: HTTPLogErrors = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "HTTPLogErrors"
         ) as HTTPLogErrors;
-        throw new ApiException<HTTPLogErrors>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<HTTPLogErrors>(
@@ -476,6 +479,7 @@ export class LogsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<HTTPLogErrors>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/LogsArchivesApi.ts
+++ b/packages/datadog-api-client-v2/apis/LogsArchivesApi.ts
@@ -470,12 +470,12 @@ export class LogsArchivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -483,6 +483,7 @@ export class LogsArchivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -531,12 +532,12 @@ export class LogsArchivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -544,6 +545,7 @@ export class LogsArchivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -587,12 +589,12 @@ export class LogsArchivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -600,6 +602,7 @@ export class LogsArchivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -647,12 +650,12 @@ export class LogsArchivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -660,6 +663,7 @@ export class LogsArchivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -704,12 +708,12 @@ export class LogsArchivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -717,6 +721,7 @@ export class LogsArchivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -766,12 +771,12 @@ export class LogsArchivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -779,6 +784,7 @@ export class LogsArchivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -823,12 +829,12 @@ export class LogsArchivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -836,6 +842,7 @@ export class LogsArchivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -879,12 +886,12 @@ export class LogsArchivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -892,6 +899,7 @@ export class LogsArchivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -941,12 +949,12 @@ export class LogsArchivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -954,6 +962,7 @@ export class LogsArchivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1003,12 +1012,12 @@ export class LogsArchivesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1016,6 +1025,7 @@ export class LogsArchivesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/LogsMetricsApi.ts
+++ b/packages/datadog-api-client-v2/apis/LogsMetricsApi.ts
@@ -254,12 +254,12 @@ export class LogsMetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -267,6 +267,7 @@ export class LogsMetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -309,12 +310,12 @@ export class LogsMetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -322,6 +323,7 @@ export class LogsMetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -370,12 +372,12 @@ export class LogsMetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -383,6 +385,7 @@ export class LogsMetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -427,12 +430,12 @@ export class LogsMetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -440,6 +443,7 @@ export class LogsMetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -489,12 +493,12 @@ export class LogsMetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -502,6 +506,7 @@ export class LogsMetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/MetricsApi.ts
+++ b/packages/datadog-api-client-v2/apis/MetricsApi.ts
@@ -672,12 +672,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -685,6 +685,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -734,12 +735,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -747,6 +748,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -796,12 +798,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -809,6 +811,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -853,12 +856,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -866,6 +869,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -915,12 +919,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -928,6 +932,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -978,12 +983,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -991,6 +996,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1040,12 +1046,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1053,6 +1059,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1102,12 +1109,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1115,6 +1122,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1165,12 +1173,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1178,6 +1186,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1227,12 +1236,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1240,6 +1249,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1290,12 +1300,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1303,6 +1313,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1352,12 +1363,12 @@ export class MetricsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1365,6 +1376,7 @@ export class MetricsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/OpsgenieIntegrationApi.ts
+++ b/packages/datadog-api-client-v2/apis/OpsgenieIntegrationApi.ts
@@ -255,12 +255,12 @@ export class OpsgenieIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -268,6 +268,7 @@ export class OpsgenieIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -311,12 +312,12 @@ export class OpsgenieIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -324,6 +325,7 @@ export class OpsgenieIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -374,12 +376,12 @@ export class OpsgenieIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -387,6 +389,7 @@ export class OpsgenieIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -431,12 +434,12 @@ export class OpsgenieIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -444,6 +447,7 @@ export class OpsgenieIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -494,12 +498,12 @@ export class OpsgenieIntegrationApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -507,6 +511,7 @@ export class OpsgenieIntegrationApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/OrganizationsApi.ts
+++ b/packages/datadog-api-client-v2/apis/OrganizationsApi.ts
@@ -79,12 +79,12 @@ export class OrganizationsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -92,6 +92,7 @@ export class OrganizationsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/ProcessesApi.ts
+++ b/packages/datadog-api-client-v2/apis/ProcessesApi.ts
@@ -120,12 +120,12 @@ export class ProcessesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -133,6 +133,7 @@ export class ProcessesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/RUMApi.ts
+++ b/packages/datadog-api-client-v2/apis/RUMApi.ts
@@ -418,12 +418,12 @@ export class RUMApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -431,6 +431,7 @@ export class RUMApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -475,12 +476,12 @@ export class RUMApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -488,6 +489,7 @@ export class RUMApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -526,12 +528,12 @@ export class RUMApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -539,6 +541,7 @@ export class RUMApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -583,12 +586,12 @@ export class RUMApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -596,6 +599,7 @@ export class RUMApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -640,12 +644,12 @@ export class RUMApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -653,6 +657,7 @@ export class RUMApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -701,12 +706,12 @@ export class RUMApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -714,6 +719,7 @@ export class RUMApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -762,12 +768,12 @@ export class RUMApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -775,6 +781,7 @@ export class RUMApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -824,12 +831,12 @@ export class RUMApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -837,6 +844,7 @@ export class RUMApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/RolesApi.ts
+++ b/packages/datadog-api-client-v2/apis/RolesApi.ts
@@ -705,12 +705,12 @@ export class RolesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -718,6 +718,7 @@ export class RolesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -767,12 +768,12 @@ export class RolesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -780,6 +781,7 @@ export class RolesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -828,12 +830,12 @@ export class RolesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -841,6 +843,7 @@ export class RolesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -889,12 +892,12 @@ export class RolesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -902,6 +905,7 @@ export class RolesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -944,12 +948,12 @@ export class RolesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -957,6 +961,7 @@ export class RolesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1003,12 +1008,12 @@ export class RolesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1016,6 +1021,7 @@ export class RolesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1064,12 +1070,12 @@ export class RolesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1077,6 +1083,7 @@ export class RolesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1125,12 +1132,12 @@ export class RolesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1138,6 +1145,7 @@ export class RolesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1180,12 +1188,12 @@ export class RolesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1193,6 +1201,7 @@ export class RolesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1241,12 +1250,12 @@ export class RolesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1254,6 +1263,7 @@ export class RolesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1303,12 +1313,12 @@ export class RolesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1316,6 +1326,7 @@ export class RolesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1365,12 +1376,12 @@ export class RolesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1378,6 +1389,7 @@ export class RolesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1428,12 +1440,12 @@ export class RolesApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1441,6 +1453,7 @@ export class RolesApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/SecurityMonitoringApi.ts
+++ b/packages/datadog-api-client-v2/apis/SecurityMonitoringApi.ts
@@ -830,12 +830,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -843,6 +843,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -891,12 +892,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -904,6 +905,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -946,12 +948,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -959,6 +961,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1003,12 +1006,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1016,6 +1019,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1066,12 +1070,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1079,6 +1083,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1130,12 +1135,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1143,6 +1148,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1194,12 +1200,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1207,6 +1213,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1256,12 +1263,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1269,6 +1276,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1313,12 +1321,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1326,6 +1334,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1370,12 +1379,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1383,6 +1392,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1427,12 +1437,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1440,6 +1450,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1485,12 +1496,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1498,6 +1509,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1548,12 +1560,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1561,6 +1573,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1611,12 +1624,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1624,6 +1637,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1675,12 +1689,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1688,6 +1702,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1738,12 +1753,12 @@ export class SecurityMonitoringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1751,6 +1766,7 @@ export class SecurityMonitoringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/ServiceAccountsApi.ts
+++ b/packages/datadog-api-client-v2/apis/ServiceAccountsApi.ts
@@ -363,12 +363,12 @@ export class ServiceAccountsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -376,6 +376,7 @@ export class ServiceAccountsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -420,12 +421,12 @@ export class ServiceAccountsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -433,6 +434,7 @@ export class ServiceAccountsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -481,12 +483,12 @@ export class ServiceAccountsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -494,6 +496,7 @@ export class ServiceAccountsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -543,12 +546,12 @@ export class ServiceAccountsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -556,6 +559,7 @@ export class ServiceAccountsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -605,12 +609,12 @@ export class ServiceAccountsApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -618,6 +622,7 @@ export class ServiceAccountsApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/UsageMeteringApi.ts
+++ b/packages/datadog-api-client-v2/apis/UsageMeteringApi.ts
@@ -483,12 +483,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -496,6 +496,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -544,12 +545,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -557,6 +558,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -605,12 +607,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -618,6 +620,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -666,12 +669,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -679,6 +682,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -728,12 +732,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -741,6 +745,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -791,12 +796,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -804,6 +809,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -854,12 +860,12 @@ export class UsageMeteringApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -867,6 +873,7 @@ export class UsageMeteringApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/packages/datadog-api-client-v2/apis/UsersApi.ts
+++ b/packages/datadog-api-client-v2/apis/UsersApi.ts
@@ -507,12 +507,12 @@ export class UsersApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -520,6 +520,7 @@ export class UsersApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -566,12 +567,12 @@ export class UsersApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -579,6 +580,7 @@ export class UsersApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -621,12 +623,12 @@ export class UsersApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -634,6 +636,7 @@ export class UsersApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -682,12 +685,12 @@ export class UsersApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -695,6 +698,7 @@ export class UsersApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -741,12 +745,12 @@ export class UsersApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -754,6 +758,7 @@ export class UsersApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -802,12 +807,12 @@ export class UsersApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -815,6 +820,7 @@ export class UsersApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -863,12 +869,12 @@ export class UsersApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -876,6 +882,7 @@ export class UsersApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -922,12 +929,12 @@ export class UsersApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -935,6 +942,7 @@ export class UsersApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -983,12 +991,12 @@ export class UsersApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -996,6 +1004,7 @@ export class UsersApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -1044,12 +1053,12 @@ export class UsersApiResponseProcessor {
         await response.body.text(),
         contentType
       );
+      let body: APIErrorResponse;
       try {
-        const body: APIErrorResponse = ObjectSerializer.deserialize(
+        body = ObjectSerializer.deserialize(
           bodyText,
           "APIErrorResponse"
         ) as APIErrorResponse;
-        throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
       } catch (error) {
         logger.info(`Got error deserializing error: ${error}`);
         throw new ApiException<APIErrorResponse>(
@@ -1057,6 +1066,7 @@ export class UsersApiResponseProcessor {
           bodyText
         );
       }
+      throw new ApiException<APIErrorResponse>(response.httpStatusCode, body);
     }
 
     // Work around for missing responses in specification, e.g. for petstore.yaml


### PR DESCRIPTION
We never returned the parsed object type. This also fixes ApiException prototype.