### PR TITLE
fix(runtimes): Allow datadog-api-client to work in Vercel's Edge Runtime

### DIFF
--- a/.generator/src/generator/templates/configuration.j2
+++ b/.generator/src/generator/templates/configuration.j2
@@ -2,7 +2,7 @@ import { HttpLibrary, HttpConfiguration, RequestContext, ZstdCompressorCallback 
 import { IsomorphicFetchHttpLibrary as DefaultHttpLibrary } from "./http/isomorphic-fetch";
 import { BaseServerConfiguration, server1, servers, operationServers } from "./servers";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth";
-import { isNode } from "./util";
+import { isNode, isEdgeRuntime } from "./util";
 
 export interface Configuration {
   readonly baseServer?: BaseServerConfiguration;
@@ -69,7 +69,7 @@ export interface ConfigurationParameters {
  * @param conf partial configuration
  */
 export function createConfiguration(conf: ConfigurationParameters = {}): Configuration {
-  if (isNode && process.env.DD_SITE) {
+  if ((isNode || isEdgeRuntime) && process.env.DD_SITE) {
     const serverConf = server1.getConfiguration();
     server1.setVariables({"site": process.env.DD_SITE} as (typeof serverConf));
     for (const op in operationServers) {
@@ -80,7 +80,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
   const authMethods = conf.authMethods || {};
   {%- for name, schema in openapi.components.securitySchemes.items()  %}
   {%- if schema.get("type") == "apiKey" and schema.get("in") == "header" %}
-  if (!("{{ name }}" in authMethods) && isNode && process.env.{{ schema["x-env-name"] }}) {
+  if (!("{{ name }}" in authMethods) && (isNode || isEdgeRuntime) && process.env.{{ schema["x-env-name"] }}) {
     authMethods["{{ name }}"] = process.env.{{ schema["x-env-name"] }};
   }
   {%- endif %}

--- a/.generator/src/generator/templates/util.j2
+++ b/.generator/src/generator/templates/util.j2
@@ -17,4 +17,6 @@ export type AttributeTypeMap = {
 
 export const isBrowser: boolean = typeof window !== "undefined" && typeof window.document !== "undefined";
 
-export const isNode: boolean = typeof process !== "undefined" && process.release.name === 'node';
+export const isNode: boolean = typeof process !== "undefined" && process.release && process.release.name === 'node';
+
+export const isEdgeRuntime: boolean = typeof EdgeRuntime === 'string';

--- a/edge-runtime-type.ts
+++ b/edge-runtime-type.ts
@@ -1,0 +1,5 @@
+export {};
+
+declare global {
+  const EdgeRuntime: Record<never, never>;
+}

--- a/logger.ts
+++ b/logger.ts
@@ -1,6 +1,13 @@
 import log from "loglevel";
 
 const logger = log.noConflict();
-logger.setLevel((typeof process !== "undefined" && process.release.name === 'node' && process.env.DEBUG) ? logger.levels.DEBUG : logger.levels.INFO);
+logger.setLevel(
+  (typeof process !== "undefined" &&
+    process.release &&
+    process.release.name === "node") ||
+    (typeof EdgeRuntime === "string" && process.env.DEBUG)
+    ? logger.levels.DEBUG
+    : logger.levels.INFO
+);
 
 export { logger };

--- a/packages/datadog-api-client-common/configuration.ts
+++ b/packages/datadog-api-client-common/configuration.ts
@@ -16,7 +16,7 @@ import {
   AuthMethods,
   AuthMethodsConfiguration,
 } from "./auth";
-import { isNode } from "./util";
+import { isNode, isEdgeRuntime } from "./util";
 
 export interface Configuration {
   readonly baseServer?: BaseServerConfiguration;
@@ -84,7 +84,7 @@ export interface ConfigurationParameters {
 export function createConfiguration(
   conf: ConfigurationParameters = {}
 ): Configuration {
-  if (isNode && process.env.DD_SITE) {
+  if ((isNode || isEdgeRuntime) && process.env.DD_SITE) {
     const serverConf = server1.getConfiguration();
     server1.setVariables({ site: process.env.DD_SITE } as typeof serverConf);
     for (const op in operationServers) {
@@ -93,10 +93,10 @@ export function createConfiguration(
   }
 
   const authMethods = conf.authMethods || {};
-  if (!("apiKeyAuth" in authMethods) && isNode && process.env.DD_API_KEY) {
+  if (!("apiKeyAuth" in authMethods) && (isNode || isEdgeRuntime) && process.env.DD_API_KEY) {
     authMethods["apiKeyAuth"] = process.env.DD_API_KEY;
   }
-  if (!("appKeyAuth" in authMethods) && isNode && process.env.DD_APP_KEY) {
+  if (!("appKeyAuth" in authMethods) && (isNode || isEdgeRuntime) && process.env.DD_APP_KEY) {
     authMethods["appKeyAuth"] = process.env.DD_APP_KEY;
   }
 

--- a/packages/datadog-api-client-common/util.ts
+++ b/packages/datadog-api-client-common/util.ts
@@ -18,4 +18,6 @@ export const isBrowser: boolean =
   typeof window !== "undefined" && typeof window.document !== "undefined";
 
 export const isNode: boolean =
-  typeof process !== "undefined" && process.release.name === "node";
+  typeof process !== "undefined" && process.release && process.release.name === "node";
+
+export const isEdgeRuntime: boolean = typeof EdgeRuntime === 'string';

--- a/userAgent.ts
+++ b/userAgent.ts
@@ -1,10 +1,12 @@
 import { version } from "./version";
 
 export let userAgent: string;
-if (typeof process !== 'undefined' && process.release.name === 'node') {
+if (typeof process !== 'undefined' && process.release && process.release.name === 'node') {
     userAgent = `datadog-api-client-typescript/${version} (node ${process.versions.node}; os ${process.platform}; arch ${process.arch})`
 } else if (typeof window !== "undefined" && typeof window.document !== "undefined") {
     // we don't set user-agent headers in browsers
+} else if (typeof EdgeRuntime === 'string') {
+    userAgent = `datadog-api-client-typescript/${version} (edge-runtime)`
 } else {
     userAgent = `datadog-api-client-typescript/${version} (runtime unknown)`
 }


### PR DESCRIPTION
### What does this PR do?

Before this commit, datadog-api-client was not compatible with Vercel's Edge Runtime (https://edge-runtime.vercel.app/).

1. While `process` exists, process.release doesn't. So changes from https://github.com/DataDog/datadog-api-client-typescript/pull/899/ were not complete
2. I added a few more code to really identify Edge Runtime as a different Node.js (server) environment that can use fetch

Let me know if that's OK.

### Additional Notes

n/a

### Review checklist

Please check relevant items below:

n/a [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests
- [x] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.