### PR TITLE
Reduce and relax `isNode` check

### DIFF
--- a/.generator/src/generator/templates/configuration.j2
+++ b/.generator/src/generator/templates/configuration.j2
@@ -2,7 +2,6 @@ import { HttpLibrary, HttpConfiguration, RequestContext, ZstdCompressorCallback 
 import { IsomorphicFetchHttpLibrary as DefaultHttpLibrary } from "./http/isomorphic-fetch";
 import { BaseServerConfiguration, server1, servers, operationServers } from "./servers";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth";
-import { isNode } from "./util";
 
 export interface Configuration {
   readonly baseServer?: BaseServerConfiguration;
@@ -69,7 +68,7 @@ export interface ConfigurationParameters {
  * @param conf partial configuration
  */
 export function createConfiguration(conf: ConfigurationParameters = {}): Configuration {
-  if (isNode && process.env.DD_SITE) {
+  if (typeof process !== "undefined" && process.env && process.env.DD_SITE) {
     const serverConf = server1.getConfiguration();
     server1.setVariables({"site": process.env.DD_SITE} as (typeof serverConf));
     for (const op in operationServers) {
@@ -80,7 +79,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
   const authMethods = conf.authMethods || {};
   {%- for name, schema in openapi.components.securitySchemes.items()  %}
   {%- if schema.get("type") == "apiKey" and schema.get("in") == "header" %}
-  if (!("{{ name }}" in authMethods) && isNode && process.env.{{ schema["x-env-name"] }}) {
+  if (!("{{ name }}" in authMethods) && process.env && process.env.{{ schema["x-env-name"] }}) {
     authMethods["{{ name }}"] = process.env.{{ schema["x-env-name"] }};
   }
   {%- endif %}

--- a/.generator/src/generator/templates/configuration.j2
+++ b/.generator/src/generator/templates/configuration.j2
@@ -79,7 +79,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
   const authMethods = conf.authMethods || {};
   {%- for name, schema in openapi.components.securitySchemes.items()  %}
   {%- if schema.get("type") == "apiKey" and schema.get("in") == "header" %}
-  if (!("{{ name }}" in authMethods) && process.env && process.env.{{ schema["x-env-name"] }}) {
+  if (!("{{ name }}" in authMethods) && typeof process !== "undefined" && process.env && process.env.{{ schema["x-env-name"] }}) {
     authMethods["{{ name }}"] = process.env.{{ schema["x-env-name"] }};
   }
   {%- endif %}

--- a/.generator/src/generator/templates/util.j2
+++ b/.generator/src/generator/templates/util.j2
@@ -17,4 +17,4 @@ export type AttributeTypeMap = {
 
 export const isBrowser: boolean = typeof window !== "undefined" && typeof window.document !== "undefined";
 
-export const isNode: boolean = typeof process !== "undefined" && process.release.name === 'node';
+export const isNode: boolean = typeof process !== "undefined" && process.release && process.release.name === 'node';

--- a/logger.ts
+++ b/logger.ts
@@ -1,6 +1,6 @@
 import log from "loglevel";
 
 const logger = log.noConflict();
-logger.setLevel((typeof process !== "undefined" && process.release.name === 'node' && process.env.DEBUG) ? logger.levels.DEBUG : logger.levels.INFO);
+logger.setLevel((typeof process !== "undefined" && process.env && process.env.DEBUG) ? logger.levels.DEBUG : logger.levels.INFO);
 
 export { logger };

--- a/packages/datadog-api-client-common/configuration.ts
+++ b/packages/datadog-api-client-common/configuration.ts
@@ -92,10 +92,20 @@ export function createConfiguration(
   }
 
   const authMethods = conf.authMethods || {};
-  if (!("apiKeyAuth" in authMethods) && process.env && process.env.DD_API_KEY) {
+  if (
+    !("apiKeyAuth" in authMethods) &&
+    typeof process !== "undefined" &&
+    process.env &&
+    process.env.DD_API_KEY
+  ) {
     authMethods["apiKeyAuth"] = process.env.DD_API_KEY;
   }
-  if (!("appKeyAuth" in authMethods) && process.env && process.env.DD_APP_KEY) {
+  if (
+    !("appKeyAuth" in authMethods) &&
+    typeof process !== "undefined" &&
+    process.env &&
+    process.env.DD_APP_KEY
+  ) {
     authMethods["appKeyAuth"] = process.env.DD_APP_KEY;
   }
 

--- a/packages/datadog-api-client-common/configuration.ts
+++ b/packages/datadog-api-client-common/configuration.ts
@@ -16,7 +16,6 @@ import {
   AuthMethods,
   AuthMethodsConfiguration,
 } from "./auth";
-import { isNode } from "./util";
 
 export interface Configuration {
   readonly baseServer?: BaseServerConfiguration;
@@ -84,7 +83,7 @@ export interface ConfigurationParameters {
 export function createConfiguration(
   conf: ConfigurationParameters = {}
 ): Configuration {
-  if (isNode && process.env.DD_SITE) {
+  if (typeof process !== "undefined" && process.env && process.env.DD_SITE) {
     const serverConf = server1.getConfiguration();
     server1.setVariables({ site: process.env.DD_SITE } as typeof serverConf);
     for (const op in operationServers) {
@@ -93,10 +92,10 @@ export function createConfiguration(
   }
 
   const authMethods = conf.authMethods || {};
-  if (!("apiKeyAuth" in authMethods) && isNode && process.env.DD_API_KEY) {
+  if (!("apiKeyAuth" in authMethods) && process.env && process.env.DD_API_KEY) {
     authMethods["apiKeyAuth"] = process.env.DD_API_KEY;
   }
-  if (!("appKeyAuth" in authMethods) && isNode && process.env.DD_APP_KEY) {
+  if (!("appKeyAuth" in authMethods) && process.env && process.env.DD_APP_KEY) {
     authMethods["appKeyAuth"] = process.env.DD_APP_KEY;
   }
 

--- a/packages/datadog-api-client-common/util.ts
+++ b/packages/datadog-api-client-common/util.ts
@@ -18,4 +18,6 @@ export const isBrowser: boolean =
   typeof window !== "undefined" && typeof window.document !== "undefined";
 
 export const isNode: boolean =
-  typeof process !== "undefined" && process.release.name === "node";
+  typeof process !== "undefined" &&
+  process.release &&
+  process.release.name === "node";

--- a/userAgent.ts
+++ b/userAgent.ts
@@ -1,7 +1,7 @@
 import { version } from "./version";
 
 export let userAgent: string;
-if (typeof process !== 'undefined' && process.release.name === 'node') {
+if (typeof process !== 'undefined' && process.release && process.release.name === 'node') {
     userAgent = `datadog-api-client-typescript/${version} (node ${process.versions.node}; os ${process.platform}; arch ${process.arch})`
 } else if (typeof window !== "undefined" && typeof window.document !== "undefined") {
     // we don't set user-agent headers in browsers


### PR DESCRIPTION
This is a followup to https://github.com/DataDog/datadog-api-client-typescript/pull/934 (Thanks for the contribution)

We want to reduce and relax the isNode check usage to support wider range of environments outside of node where process object is available but not release information, etc. See above issue as well for one of the usecases. 