### PR TITLE
Handle dict keys with special characters

### DIFF
--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -382,7 +382,7 @@ def format_data_with_schema_dict(
     if parameters == "":
         # TODO select oneOf based on data
         warnings.warn(f"No schema matched for {data}")
-        parameters = ", ".join(f"{k}: \"{v}\"" for k, v in data.items())
+        parameters = ", ".join(f"\"{k}\": \"{v}\"" for k, v in data.items())
 
     return f"{{\n{parameters}}}"
 


### PR DESCRIPTION
Prevent the example generation from breaking when dictionary keys have special characters