### PR TITLE
Fix dateToRFC3339String parsing

### DIFF
--- a/.generator/src/generator/templates/util.j2
+++ b/.generator/src/generator/templates/util.j2
@@ -48,8 +48,8 @@ export function dateToRFC3339String(date: Date | DDate): string {
   const year = date.getFullYear() ;
   const month = date.getMonth();
   const day = date.getUTCDate();
-  const hour = date.getUTCHours() + +tzHour;
-  const minute = date.getUTCMinutes() + +tzMin;
+  const hour = date.getUTCHours() + tzHour;
+  const minute = date.getUTCMinutes() + tzMin;
   const second = date.getUTCSeconds();
 
   let msec = date.getUTCMilliseconds().toString();
@@ -81,13 +81,5 @@ function getRFC3339TimezoneOffset(date: Date | DDate): string {
   if (date instanceof DDate && date.rfc3339TzOffset) {
     return date.rfc3339TzOffset;
   }
-
-  let offset = date.getTimezoneOffset()
-  if (offset === 0) {
-      return "Z";
-  }
-
-  const offsetSign = (offset > 0) ? "+" : "-";
-  offset = Math.abs(offset);
-  return offsetSign + pad(Math.floor(offset / 60)) + ":" + pad(offset % 60);
+  return "Z";
 }

--- a/packages/datadog-api-client-common/util.ts
+++ b/packages/datadog-api-client-common/util.ts
@@ -52,8 +52,8 @@ export function dateToRFC3339String(date: Date | DDate): string {
   const year = date.getFullYear();
   const month = date.getMonth();
   const day = date.getUTCDate();
-  const hour = date.getUTCHours() + +tzHour;
-  const minute = date.getUTCMinutes() + +tzMin;
+  const hour = date.getUTCHours() + tzHour;
+  const minute = date.getUTCMinutes() + tzMin;
   const second = date.getUTCSeconds();
 
   let msec = date.getUTCMilliseconds().toString();
@@ -92,13 +92,5 @@ function getRFC3339TimezoneOffset(date: Date | DDate): string {
   if (date instanceof DDate && date.rfc3339TzOffset) {
     return date.rfc3339TzOffset;
   }
-
-  let offset = date.getTimezoneOffset();
-  if (offset === 0) {
-    return "Z";
-  }
-
-  const offsetSign = offset > 0 ? "+" : "-";
-  offset = Math.abs(offset);
-  return offsetSign + pad(Math.floor(offset / 60)) + ":" + pad(offset % 60);
+  return "Z";
 }

--- a/tests/api/date_time.test.ts
+++ b/tests/api/date_time.test.ts
@@ -1,5 +1,6 @@
 import { MonthlyUsageAttributionResponse } from '../../packages/datadog-api-client-v1/models/MonthlyUsageAttributionResponse';
 import { ObjectSerializer as ObjectSerializerV1 } from '../../packages/datadog-api-client-v1/models/ObjectSerializer';
+import { dateToRFC3339String } from "../../packages/datadog-api-client-common/util";
 
 test('TestDeserializationOfInvalidDates', () => {
   const data = `
@@ -42,4 +43,11 @@ test('TestDeserializationOfInvalidDates', () => {
     expect(result).toBeInstanceOf(MonthlyUsageAttributionResponse)
     expect(result.usage[0].updatedAt).toBeInstanceOf(Date);
   }
+);
+
+test(`Test3339Dates`, () => {
+  const date = new Date("2023-06-13T21:30:48-10:00");
+  const result = dateToRFC3339String(date);
+  expect(result).toBe("2023-06-14T07:30:48Z");
+}
 );


### PR DESCRIPTION
We can't use `getTimezoneOffset` as it's a local value independent of the Date object passed.

Fixes #1200
