### PR TITLE
Fix datetime handling more broadly

### DIFF
--- a/.generator/src/generator/templates/util.j2
+++ b/.generator/src/generator/templates/util.j2
@@ -45,16 +45,3 @@ export function dateToRFC3339String(date: Date | DDate): string {
    }
    return date.toISOString().split('.')[0] + "Z";
 }
-
-// Helpers
-function pad(num: number, len = 2): string {
-  let paddedNum = num.toString();
-  if (paddedNum.length < len) {
-    paddedNum = "0".repeat(len - paddedNum.length) + paddedNum;
-  } else if (paddedNum.length > len) {
-    paddedNum = paddedNum.slice(0, len);
-  }
-
-  return paddedNum;
-}
-

--- a/.generator/src/generator/templates/util.j2
+++ b/.generator/src/generator/templates/util.j2
@@ -1,7 +1,6 @@
-
 export class UnparsedObject {
-  _data:any;
-  constructor(data:any) {
+  _data: any;
+  constructor(data: any) {
     this._data = data;
   }
 }
@@ -13,73 +12,49 @@ export type AttributeTypeMap = {
     required?: boolean;
     format?: string;
   };
-}
+};
 
-export const isBrowser: boolean = typeof window !== "undefined" && typeof window.document !== "undefined";
+export const isBrowser: boolean =
+  typeof window !== "undefined" && typeof window.document !== "undefined";
 
-export const isNode: boolean = typeof process !== "undefined" && process.release && process.release.name === 'node';
+export const isNode: boolean =
+  typeof process !== "undefined" &&
+  process.release &&
+  process.release.name === "node";
 
 export class DDate extends Date {
-  rfc3339TzOffset: string | undefined;
+  originalDate: string | undefined;
 }
 
-const RFC3339Re: RegExp = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})\.?(\d+)?(?:(?:([+-]\d{2}):?(\d{2}))|Z)?$/;
+const RFC3339Re =
+  /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})\.?(\d+)?(?:(?:([+-]\d{2}):?(\d{2}))|Z)?$/;
 export function dateFromRFC3339String(date: string): DDate {
   const m = RFC3339Re.exec(date);
   if (m) {
-    const _date = new DDate(date)
-    if( m[8] === undefined && m[9] === undefined){
-      _date.rfc3339TzOffset = 'Z'
-    } else {
-      _date.rfc3339TzOffset = `${m[8]}:${m[9]}`
-    }
-
-    return _date
+    const _date = new DDate(date);
+    _date.originalDate = date;
+    return _date;
   } else {
-    throw new Error('unexpected date format: ' + date)
+    throw new Error("unexpected date format: " + date);
   }
 }
 
 export function dateToRFC3339String(date: Date | DDate): string {
-  const offSetArr = getRFC3339TimezoneOffset(date).split(":")
-  const tzHour = offSetArr.length == 1 ? 0 : +offSetArr[0];
-  const tzMin  = offSetArr.length == 1 ? 0 : +offSetArr[1];
-
-  const year = date.getFullYear() ;
-  const month = date.getMonth();
-  const day = date.getUTCDate();
-  const hour = date.getUTCHours() + tzHour;
-  const minute = date.getUTCMinutes() + tzMin;
-  const second = date.getUTCSeconds();
-
-  let msec = date.getUTCMilliseconds().toString();
-  msec = +msec === 0 ? "" : `.${pad(+msec, 3)}`
-
-  return year + "-" +
-    pad(month + 1) + "-" +
-    pad(day) + "T" +
-    pad(hour) + ":" +
-    pad(minute) + ":" +
-    pad(second) +
-    msec +
-    offSetArr.join(":");
+   if (date instanceof DDate && date.originalDate) {
+     return date.originalDate;
+   }
+   return date.toISOString().split('.')[0] + "Z";
 }
 
 // Helpers
-function pad(num: number, len: number = 2): string {
-  let paddedNum = num.toString()
+function pad(num: number, len = 2): string {
+  let paddedNum = num.toString();
   if (paddedNum.length < len) {
-    paddedNum = "0".repeat(len - paddedNum.length) + paddedNum
+    paddedNum = "0".repeat(len - paddedNum.length) + paddedNum;
   } else if (paddedNum.length > len) {
-    paddedNum = paddedNum.slice(0, len)
+    paddedNum = paddedNum.slice(0, len);
   }
 
-  return paddedNum
+  return paddedNum;
 }
 
-function getRFC3339TimezoneOffset(date: Date | DDate): string {
-  if (date instanceof DDate && date.rfc3339TzOffset) {
-    return date.rfc3339TzOffset;
-  }
-  return "Z";
-}

--- a/packages/datadog-api-client-common/util.ts
+++ b/packages/datadog-api-client-common/util.ts
@@ -40,10 +40,10 @@ export function dateFromRFC3339String(date: string): DDate {
 }
 
 export function dateToRFC3339String(date: Date | DDate): string {
-   if (date instanceof DDate && date.originalDate) {
-     return date.originalDate;
-   }
-   return date.toISOString().split('.')[0] + "Z";
+  if (date instanceof DDate && date.originalDate) {
+    return date.originalDate;
+  }
+  return date.toISOString().split(".")[0] + "Z";
 }
 
 // Helpers

--- a/packages/datadog-api-client-common/util.ts
+++ b/packages/datadog-api-client-common/util.ts
@@ -45,15 +45,3 @@ export function dateToRFC3339String(date: Date | DDate): string {
   }
   return date.toISOString().split(".")[0] + "Z";
 }
-
-// Helpers
-function pad(num: number, len = 2): string {
-  let paddedNum = num.toString();
-  if (paddedNum.length < len) {
-    paddedNum = "0".repeat(len - paddedNum.length) + paddedNum;
-  } else if (paddedNum.length > len) {
-    paddedNum = paddedNum.slice(0, len);
-  }
-
-  return paddedNum;
-}

--- a/tests/api/date_time.test.ts
+++ b/tests/api/date_time.test.ts
@@ -1,6 +1,6 @@
 import { MonthlyUsageAttributionResponse } from '../../packages/datadog-api-client-v1/models/MonthlyUsageAttributionResponse';
 import { ObjectSerializer as ObjectSerializerV1 } from '../../packages/datadog-api-client-v1/models/ObjectSerializer';
-import { dateToRFC3339String } from "../../packages/datadog-api-client-common/util";
+import { dateFromRFC3339String, dateToRFC3339String } from "../../packages/datadog-api-client-common/util";
 
 test('TestDeserializationOfInvalidDates', () => {
   const data = `
@@ -49,5 +49,12 @@ test(`Test3339Dates`, () => {
   const date = new Date("2023-06-13T21:30:48-10:00");
   const result = dateToRFC3339String(date);
   expect(result).toBe("2023-06-14T07:30:48Z");
+}
+);
+
+test(`Test3339DatesWithTZ`, () => {
+  const date = dateFromRFC3339String("2023-06-13T21:30:48-10:00");
+  const result = dateToRFC3339String(date);
+  expect(result).toBe("2023-06-13T21:30:48-10:00");
 }
 );


### PR DESCRIPTION
We want the custom date object to be able to round-trip the date between responses and requests. Instead of doing calculations, let's just store the original string to send it back when needed.
