### PR TITLE
Only serialize existing data

### DIFF
--- a/.generator/src/generator/templates/model/ObjectSerializer.j2
+++ b/.generator/src/generator/templates/model/ObjectSerializer.j2
@@ -127,24 +127,38 @@ export class ObjectSerializer {
       const attributesMap = typeMap[type].getAttributeTypeMap();
       const instance: {[index: string]: any} = {};
 
-      for (const attributeName in attributesMap) {
+      for (const attributeName in data) {
         const attributeObj = attributesMap[attributeName];
-        if (attributeName == "additionalProperties") {
-          if (data.additionalProperties) {
-            for (const key in data.additionalProperties) {
-              instance[key] = ObjectSerializer.serialize(
-                data.additionalProperties[key],
-                attributeObj.type,
-                attributeObj.format
-              );
-            }
-          }
+        if (attributeName === "_unparsed" || attributeName === "additionalProperties") {
           continue;
+        } else if (attributeObj) {
+          instance[attributeObj.baseName] = ObjectSerializer.serialize(
+            data[attributeName],
+            attributeObj.type,
+            attributeObj.format
+          );
+        } else {
+          throw new Error('unknown attribute ' + attributeName + ' of type ' + type);
         }
-        instance[attributeObj.baseName] = ObjectSerializer.serialize(data[attributeName], attributeObj.type, attributeObj.format);
         // check for required properties
-        if (attributeObj?.required && instance[attributeObj.baseName] === undefined) {
-          throw new Error(`missing required property '${attributeObj.baseName}'`);
+        if (
+          attributeObj?.required &&
+          instance[attributeObj.baseName] === undefined
+        ) {
+          throw new Error(
+            `missing required property '${attributeObj.baseName}'`
+          );
+        }
+      }
+
+      let additionalProperties = attributesMap["additionalProperties"]
+      if (additionalProperties && data.additionalProperties) {
+        for (const key in data.additionalProperties) {
+          instance[key] = ObjectSerializer.serialize(
+            data.additionalProperties[key],
+            additionalProperties.type,
+            additionalProperties.format
+          );
         }
       }
 

--- a/packages/datadog-api-client-v2/models/ObjectSerializer.ts
+++ b/packages/datadog-api-client-v2/models/ObjectSerializer.ts
@@ -3057,25 +3057,24 @@ export class ObjectSerializer {
       const attributesMap = typeMap[type].getAttributeTypeMap();
       const instance: { [index: string]: any } = {};
 
-      for (const attributeName in attributesMap) {
+      for (const attributeName in data) {
         const attributeObj = attributesMap[attributeName];
-        if (attributeName == "additionalProperties") {
-          if (data.additionalProperties) {
-            for (const key in data.additionalProperties) {
-              instance[key] = ObjectSerializer.serialize(
-                data.additionalProperties[key],
-                attributeObj.type,
-                attributeObj.format
-              );
-            }
-          }
+        if (
+          attributeName === "_unparsed" ||
+          attributeName === "additionalProperties"
+        ) {
           continue;
+        } else if (attributeObj) {
+          instance[attributeObj.baseName] = ObjectSerializer.serialize(
+            data[attributeName],
+            attributeObj.type,
+            attributeObj.format
+          );
+        } else {
+          throw new Error(
+            "unknown attribute " + attributeName + " of type " + type
+          );
         }
-        instance[attributeObj.baseName] = ObjectSerializer.serialize(
-          data[attributeName],
-          attributeObj.type,
-          attributeObj.format
-        );
         // check for required properties
         if (
           attributeObj?.required &&
@@ -3083,6 +3082,17 @@ export class ObjectSerializer {
         ) {
           throw new Error(
             `missing required property '${attributeObj.baseName}'`
+          );
+        }
+      }
+
+      const additionalProperties = attributesMap["additionalProperties"];
+      if (additionalProperties && data.additionalProperties) {
+        for (const key in data.additionalProperties) {
+          instance[key] = ObjectSerializer.serialize(
+            data.additionalProperties[key],
+            additionalProperties.type,
+            additionalProperties.format
           );
         }
       }


### PR DESCRIPTION
Instead of blindly attempting to serialize fields using the attribute mapping, only attempt to serialize fields that are actually in the model itself. Handles additionalProperties in a separate loop.