### PR TITLE
fix(github-workflows): use official GitHub action for token generation

### DIFF
--- a/.github/workflows/approved_status.yml
+++ b/.github/workflows/approved_status.yml
@@ -1,6 +1,6 @@
 name: Send PR Approval Status
 
-permissions: 
+permissions:
   contents: read
   pull-requests: write
 
@@ -25,10 +25,10 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get_token
-        uses: tibdex/github-app-token@v1.3.0
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private_key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
           repository: DataDog/datadog-api-spec
       - name: Post PR review status check
         uses: DataDog/github-actions/post-review-status@v2

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private_key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private_key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Create release
         uses: actions/github-script@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Run Tests
 
-permissions: 
+permissions:
   contents: read
 
 env:
@@ -31,10 +31,10 @@ jobs:
       - name: Get GitHub App token
         id: get_token
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private_key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v3
         if: github.event.pull_request.head.repo.full_name == github.repository
         with:
@@ -125,10 +125,10 @@ jobs:
       - name: Get GitHub App token
         if: github.event_name == 'pull_request'
         id: get_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private_key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
           repository: DataDog/datadog-api-spec
       - name: Post status check
         uses: DataDog/github-actions/post-status-check@v2

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -1,6 +1,6 @@
 name: Run Integration Tests
 
-permissions: 
+permissions:
   contents: read
 
 on:
@@ -44,10 +44,10 @@ jobs:
       - name: Get GitHub App token
         if: github.event_name == 'pull_request'
         id: get_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private_key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
           repository: DataDog/datadog-api-spec
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
### What does this PR do?

- Replaces usage of `tibdex/github-app-token` with official GitHub action 