### PR TITLE
[generator] fix import references

### DIFF
--- a/.generator/src/generator/openapi.py
+++ b/.generator/src/generator/openapi.py
@@ -255,7 +255,7 @@ def get_references_for_model(model, model_name):
     for key, definition in model.get("properties", {}).items():
         if definition.get("type") == "object" or definition.get("enum") or definition.get("oneOf"):
             name = formatter.get_name(definition)
-            if name and not definition.get("additionalProperties"):
+            if name and not (definition.get("additionalProperties", False) != False and not definition.get("properties")):
                 result.append(name)
             elif definition.get("properties") and top_name:
                 result.append(top_name + formatter.camel_case(key))


### PR DESCRIPTION
### What does this PR do?

This PR fixes an inconsistency in the generator for reference imports. It aligns both `get_references_for_model` and `type_to_typescript` handling of objects with `additionalProperties` and `properties` fields.

 The bug was discovered with [this PR](https://github.com/DataDog/datadog-api-client-typescript/actions/runs/13661731800/job/38231423045).

For the given specification:
```
components:
  schemas:
    ApplicationSecurityWafCustomRuleCreateAttributes:
      type: object
      description: "Create a new WAF custom rule."
      properties:
        ...
        tags:
          $ref: "#/components/schemas/ApplicationSecurityWafCustomRuleTags"

    ApplicationSecurityWafCustomRuleTags:
      type: object
      description: |-
        Tags associated with the WAF Custom Rule. The concatenation of category and type will form the security
        activity field associated with the traces.
      properties:
        category:
          $ref: "#/components/schemas/ApplicationSecurityWafCustomRuleTagsCategory"
        type:
          type: string
          description: The type of the WAF rule, associated with the category will form the security activity.
          example: "users.login.success"
      additionalProperties:
        type: string
```

Without the fix the following code was generated:
```
import { ApplicationSecurityWafCustomRuleCreateAttributesTags } from "./ApplicationSecurityWafCustomRuleCreateAttributesTags";

/**
 * Create a WAF custom rule.
*/
export class ApplicationSecurityWafCustomRuleCreateAttributes {
  ...
  /**
   * Tags associated with the WAF Custom Rule. The concatenation of category and type will form the security
   * activity field associated with the traces.
  */
  "tags": ApplicationSecurityWafCustomRuleTags;
```

After the fix, the generated and correct code:
```
import { ApplicationSecurityWafCustomRuleTags } from "./ApplicationSecurityWafCustomRuleTags";

/**
 * Create a WAF custom rule.
*/
export class ApplicationSecurityWafCustomRuleCreateAttributes {
  ...
  /**
   * Tags associated with the WAF Custom Rule. The concatenation of category and type will form the security
   * activity field associated with the traces.
  */
  "tags": ApplicationSecurityWafCustomRuleTags;
```

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [X] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
