### PR TITLE
Bump common package to 2.0.0

### DIFF
--- a/packages/datadog-api-client/package.json
+++ b/packages/datadog-api-client/package.json
@@ -43,6 +43,6 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "version": "2.0.0",
+  "version": "2.0.0-beta.0",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/datadog-api-client/package.json
+++ b/packages/datadog-api-client/package.json
@@ -43,6 +43,6 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "version": "0.0.1",
+  "version": "2.0.0",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/services/action_connection/package.json
+++ b/services/action_connection/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/agentless_scanning/package.json
+++ b/services/agentless_scanning/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/api_management/package.json
+++ b/services/api_management/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/api_management/package.json
+++ b/services/api_management/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/apm_retention_filters/package.json
+++ b/services/apm_retention_filters/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/apm_retention_filters/package.json
+++ b/services/apm_retention_filters/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/app_builder/package.json
+++ b/services/app_builder/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/app_builder/package.json
+++ b/services/app_builder/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/application_security/package.json
+++ b/services/application_security/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/application_security/package.json
+++ b/services/application_security/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/auth_n_mappings/package.json
+++ b/services/auth_n_mappings/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/authentication/package.json
+++ b/services/authentication/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/aws_integration/package.json
+++ b/services/aws_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/aws_integration/package.json
+++ b/services/aws_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/aws_logs_integration/package.json
+++ b/services/aws_logs_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/azure_integration/package.json
+++ b/services/azure_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/azure_integration/package.json
+++ b/services/azure_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/case_management/package.json
+++ b/services/case_management/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/case_management/package.json
+++ b/services/case_management/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/ci_visibility_pipelines/package.json
+++ b/services/ci_visibility_pipelines/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/ci_visibility_tests/package.json
+++ b/services/ci_visibility_tests/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/ci_visibility_tests/package.json
+++ b/services/ci_visibility_tests/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/cloud_cost_management/package.json
+++ b/services/cloud_cost_management/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/cloud_network_monitoring/package.json
+++ b/services/cloud_network_monitoring/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/cloud_network_monitoring/package.json
+++ b/services/cloud_network_monitoring/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/cloudflare_integration/package.json
+++ b/services/cloudflare_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/confluent_cloud/package.json
+++ b/services/confluent_cloud/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/confluent_cloud/package.json
+++ b/services/confluent_cloud/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/container_images/package.json
+++ b/services/container_images/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/containers/package.json
+++ b/services/containers/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/csm_agents/package.json
+++ b/services/csm_agents/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/csm_agents/package.json
+++ b/services/csm_agents/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/csm_coverage_analysis/package.json
+++ b/services/csm_coverage_analysis/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/csm_coverage_analysis/package.json
+++ b/services/csm_coverage_analysis/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/csm_threats/package.json
+++ b/services/csm_threats/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/csm_threats/package.json
+++ b/services/csm_threats/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/dashboard_lists/package.json
+++ b/services/dashboard_lists/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/dashboard_lists/package.json
+++ b/services/dashboard_lists/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/dashboards/package.json
+++ b/services/dashboards/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/dashboards/package.json
+++ b/services/dashboards/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/data_deletion/package.json
+++ b/services/data_deletion/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/data_deletion/package.json
+++ b/services/data_deletion/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/domain_allowlist/package.json
+++ b/services/domain_allowlist/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/domain_allowlist/package.json
+++ b/services/domain_allowlist/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/dora_metrics/package.json
+++ b/services/dora_metrics/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/downtimes/package.json
+++ b/services/downtimes/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/downtimes/package.json
+++ b/services/downtimes/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/events/package.json
+++ b/services/events/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/fastly_integration/package.json
+++ b/services/fastly_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/gcp_integration/package.json
+++ b/services/gcp_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/gcp_integration/package.json
+++ b/services/gcp_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/hosts/package.json
+++ b/services/hosts/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/incident_services/package.json
+++ b/services/incident_services/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/incident_services/package.json
+++ b/services/incident_services/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/incident_teams/package.json
+++ b/services/incident_teams/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/incidents/package.json
+++ b/services/incidents/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/ip_allowlist/package.json
+++ b/services/ip_allowlist/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/ip_allowlist/package.json
+++ b/services/ip_allowlist/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/ip_ranges/package.json
+++ b/services/ip_ranges/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/ip_ranges/package.json
+++ b/services/ip_ranges/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/key_management/package.json
+++ b/services/key_management/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/key_management/package.json
+++ b/services/key_management/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/logs/package.json
+++ b/services/logs/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/logs/package.json
+++ b/services/logs/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/logs_archives/package.json
+++ b/services/logs_archives/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/logs_archives/package.json
+++ b/services/logs_archives/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/logs_custom_destinations/package.json
+++ b/services/logs_custom_destinations/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/logs_custom_destinations/package.json
+++ b/services/logs_custom_destinations/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/logs_indexes/package.json
+++ b/services/logs_indexes/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/logs_metrics/package.json
+++ b/services/logs_metrics/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/logs_metrics/package.json
+++ b/services/logs_metrics/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/logs_pipelines/package.json
+++ b/services/logs_pipelines/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/logs_pipelines/package.json
+++ b/services/logs_pipelines/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/metrics/package.json
+++ b/services/metrics/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/metrics/package.json
+++ b/services/metrics/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/microsoft_teams_integration/package.json
+++ b/services/microsoft_teams_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/monitors/package.json
+++ b/services/monitors/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/monitors/package.json
+++ b/services/monitors/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/network_device_monitoring/package.json
+++ b/services/network_device_monitoring/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/network_device_monitoring/package.json
+++ b/services/network_device_monitoring/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/notebooks/package.json
+++ b/services/notebooks/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/okta_integration/package.json
+++ b/services/okta_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/opsgenie_integration/package.json
+++ b/services/opsgenie_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/opsgenie_integration/package.json
+++ b/services/opsgenie_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/organizations/package.json
+++ b/services/organizations/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/organizations/package.json
+++ b/services/organizations/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/pager_duty_integration/package.json
+++ b/services/pager_duty_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/pager_duty_integration/package.json
+++ b/services/pager_duty_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/powerpack/package.json
+++ b/services/powerpack/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/powerpack/package.json
+++ b/services/powerpack/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/processes/package.json
+++ b/services/processes/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/processes/package.json
+++ b/services/processes/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/restriction_policies/package.json
+++ b/services/restriction_policies/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/restriction_policies/package.json
+++ b/services/restriction_policies/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/roles/package.json
+++ b/services/roles/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/roles/package.json
+++ b/services/roles/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/rum/package.json
+++ b/services/rum/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/rum/package.json
+++ b/services/rum/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/rum_metrics/package.json
+++ b/services/rum_metrics/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/rum_metrics/package.json
+++ b/services/rum_metrics/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/rum_retention_filters/package.json
+++ b/services/rum_retention_filters/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/security_monitoring/package.json
+++ b/services/security_monitoring/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/security_monitoring/package.json
+++ b/services/security_monitoring/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/sensitive_data_scanner/package.json
+++ b/services/sensitive_data_scanner/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/sensitive_data_scanner/package.json
+++ b/services/sensitive_data_scanner/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/service_accounts/package.json
+++ b/services/service_accounts/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/service_accounts/package.json
+++ b/services/service_accounts/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/service_checks/package.json
+++ b/services/service_checks/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/service_definition/package.json
+++ b/services/service_definition/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/service_definition/package.json
+++ b/services/service_definition/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/service_level_objective_corrections/package.json
+++ b/services/service_level_objective_corrections/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/service_level_objectives/package.json
+++ b/services/service_level_objectives/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/service_scorecards/package.json
+++ b/services/service_scorecards/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/service_scorecards/package.json
+++ b/services/service_scorecards/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/slack_integration/package.json
+++ b/services/slack_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/slack_integration/package.json
+++ b/services/slack_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/snapshots/package.json
+++ b/services/snapshots/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/snapshots/package.json
+++ b/services/snapshots/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/software_catalog/package.json
+++ b/services/software_catalog/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/software_catalog/package.json
+++ b/services/software_catalog/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/spans/package.json
+++ b/services/spans/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/spans/package.json
+++ b/services/spans/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/spans_metrics/package.json
+++ b/services/spans_metrics/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/synthetics/package.json
+++ b/services/synthetics/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/synthetics/package.json
+++ b/services/synthetics/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/tags/package.json
+++ b/services/tags/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/tags/package.json
+++ b/services/tags/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/teams/package.json
+++ b/services/teams/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/teams/package.json
+++ b/services/teams/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/usage_metering/package.json
+++ b/services/usage_metering/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/usage_metering/package.json
+++ b/services/usage_metering/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/users/package.json
+++ b/services/users/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/users/package.json
+++ b/services/users/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/webhooks_integration/package.json
+++ b/services/webhooks_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/webhooks_integration/package.json
+++ b/services/webhooks_integration/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/workflow_automation/package.json
+++ b/services/workflow_automation/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@datadog/datadog-api-client": "*"
+   "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"

--- a/services/workflow_automation/package.json
+++ b/services/workflow_automation/package.json
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-   "@datadog/datadog-api-client": "^2.0.0-beta.0"
+    "@datadog/datadog-api-client": "^2.0.0-beta.0"
   },
   "devDependencies": {
     "typescript": "4.8.4"


### PR DESCRIPTION
This is mainly for handling dependency conflicts between version released on `@datadog/datadog-api-client` and locally. 