### PR TITLE
Fix workspace ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "private": true,
   "workspaces": [
-    "services/*",
-    "packages/*"
+    "packages/*",
+    "services/*"
   ],
   "scripts": {
     "build": "yarn workspaces run build",


### PR DESCRIPTION
`packages` directory should be built before `services`