### PR TITLE
[AAWF-420] Add prepack hook to build the common and the service package

### DIFF
--- a/packages/datadog-api-client/package.json
+++ b/packages/datadog-api-client/package.json
@@ -24,6 +24,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/action_connection/package.json
+++ b/services/action_connection/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/agentless_scanning/package.json
+++ b/services/agentless_scanning/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/api_management/package.json
+++ b/services/api_management/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/apm_retention_filters/package.json
+++ b/services/apm_retention_filters/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/app_builder/package.json
+++ b/services/app_builder/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/application_security/package.json
+++ b/services/application_security/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/audit/package.json
+++ b/services/audit/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/auth_n_mappings/package.json
+++ b/services/auth_n_mappings/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/authentication/package.json
+++ b/services/authentication/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/aws_integration/package.json
+++ b/services/aws_integration/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/aws_logs_integration/package.json
+++ b/services/aws_logs_integration/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/azure_integration/package.json
+++ b/services/azure_integration/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/case_management/package.json
+++ b/services/case_management/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/ci_visibility_pipelines/package.json
+++ b/services/ci_visibility_pipelines/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/ci_visibility_tests/package.json
+++ b/services/ci_visibility_tests/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/cloud_cost_management/package.json
+++ b/services/cloud_cost_management/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/cloud_network_monitoring/package.json
+++ b/services/cloud_network_monitoring/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/cloudflare_integration/package.json
+++ b/services/cloudflare_integration/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/confluent_cloud/package.json
+++ b/services/confluent_cloud/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/container_images/package.json
+++ b/services/container_images/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/containers/package.json
+++ b/services/containers/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/csm_agents/package.json
+++ b/services/csm_agents/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/csm_coverage_analysis/package.json
+++ b/services/csm_coverage_analysis/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/csm_threats/package.json
+++ b/services/csm_threats/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/dashboard_lists/package.json
+++ b/services/dashboard_lists/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/dashboards/package.json
+++ b/services/dashboards/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/data_deletion/package.json
+++ b/services/data_deletion/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/domain_allowlist/package.json
+++ b/services/domain_allowlist/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/dora_metrics/package.json
+++ b/services/dora_metrics/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/downtimes/package.json
+++ b/services/downtimes/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/events/package.json
+++ b/services/events/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/fastly_integration/package.json
+++ b/services/fastly_integration/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/gcp_integration/package.json
+++ b/services/gcp_integration/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/hosts/package.json
+++ b/services/hosts/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/incident_services/package.json
+++ b/services/incident_services/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/incident_teams/package.json
+++ b/services/incident_teams/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/incidents/package.json
+++ b/services/incidents/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/ip_allowlist/package.json
+++ b/services/ip_allowlist/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/ip_ranges/package.json
+++ b/services/ip_ranges/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/key_management/package.json
+++ b/services/key_management/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/logs/package.json
+++ b/services/logs/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/logs_archives/package.json
+++ b/services/logs_archives/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/logs_custom_destinations/package.json
+++ b/services/logs_custom_destinations/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/logs_indexes/package.json
+++ b/services/logs_indexes/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/logs_metrics/package.json
+++ b/services/logs_metrics/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/logs_pipelines/package.json
+++ b/services/logs_pipelines/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/metrics/package.json
+++ b/services/metrics/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/microsoft_teams_integration/package.json
+++ b/services/microsoft_teams_integration/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/monitors/package.json
+++ b/services/monitors/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/network_device_monitoring/package.json
+++ b/services/network_device_monitoring/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/notebooks/package.json
+++ b/services/notebooks/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/observability_pipelines/package.json
+++ b/services/observability_pipelines/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/okta_integration/package.json
+++ b/services/okta_integration/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/on_call/package.json
+++ b/services/on_call/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/on_call_paging/package.json
+++ b/services/on_call_paging/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/opsgenie_integration/package.json
+++ b/services/opsgenie_integration/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/organizations/package.json
+++ b/services/organizations/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/pager_duty_integration/package.json
+++ b/services/pager_duty_integration/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/powerpack/package.json
+++ b/services/powerpack/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/processes/package.json
+++ b/services/processes/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/restriction_policies/package.json
+++ b/services/restriction_policies/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/roles/package.json
+++ b/services/roles/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/rum/package.json
+++ b/services/rum/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/rum_metrics/package.json
+++ b/services/rum_metrics/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/rum_retention_filters/package.json
+++ b/services/rum_retention_filters/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/security_monitoring/package.json
+++ b/services/security_monitoring/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/sensitive_data_scanner/package.json
+++ b/services/sensitive_data_scanner/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/service_accounts/package.json
+++ b/services/service_accounts/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/service_checks/package.json
+++ b/services/service_checks/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/service_definition/package.json
+++ b/services/service_definition/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/service_level_objective_corrections/package.json
+++ b/services/service_level_objective_corrections/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/service_level_objectives/package.json
+++ b/services/service_level_objectives/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/service_scorecards/package.json
+++ b/services/service_scorecards/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/slack_integration/package.json
+++ b/services/slack_integration/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/snapshots/package.json
+++ b/services/snapshots/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/software_catalog/package.json
+++ b/services/software_catalog/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/spans/package.json
+++ b/services/spans/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/spans_metrics/package.json
+++ b/services/spans_metrics/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/synthetics/package.json
+++ b/services/synthetics/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/tags/package.json
+++ b/services/tags/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/teams/package.json
+++ b/services/teams/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/usage_metering/package.json
+++ b/services/usage_metering/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/users/package.json
+++ b/services/users/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/webhooks_integration/package.json
+++ b/services/webhooks_integration/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {

--- a/services/workflow_automation/package.json
+++ b/services/workflow_automation/package.json
@@ -25,6 +25,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "prepack": "yarn workspace @datadog/datadog-api-client build && yarn build",
     "build": "tsc"
   },
   "dependencies": {


### PR DESCRIPTION
Before packing the packages, we need to:
- Build the shared package `@datadog/datadog-api-client` because yarn workspaces looks to resolve the package locally. If not satisfied, it will fall back to published npm packages.
- Build the service being released.

This PR makes use of the `prepack` hook to ensure we do both of the above. 

See: https://yarnpkg.com/advanced/lifecycle-scripts#prepack-and-postpack