### PR TITLE
fix the reusable precommit so it runs on the correct commit sha

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -81,6 +81,7 @@ jobs:
     uses: ./.github/workflows/reusable-integration-test.yml
     with:
       target-branch: ${{ inputs.target-branch }}
+      has-integration-label: ${{ contains(github.event.pull_request.labels.*.name, 'ci/integrations') }}
     secrets:
       PIPELINE_GITHUB_APP_ID: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
       PIPELINE_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -38,6 +38,11 @@ on:
         required: false
         type: string
         default: 'datadog-api-spec'
+      has-integration-label:
+        description: 'Whether the calling PR has ci/integrations label'
+        required: false
+        type: boolean
+        default: false
     secrets:
       PIPELINE_GITHUB_APP_ID:
         required: false
@@ -65,7 +70,8 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'ci/skip') &&
       !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/') &&
       contains(github.event.pull_request.labels.*.name, 'ci/integrations')) ||
-      github.event_name == 'schedule'
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_call' && inputs.has-integration-label)
     services:
       datadog-agent:
         image: gcr.io/datadoghq/agent:latest

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -58,14 +58,21 @@ jobs:
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Determine pre-commit range
+        id: commit_range
+        run: |
+          FROM_REF=$(git merge-base HEAD origin/master)
+          echo "from_ref=$FROM_REF" >> $GITHUB_OUTPUT
+          echo "to_ref=HEAD" >> $GITHUB_OUTPUT
+          echo "Pre-commit will check from $FROM_REF to HEAD"
       - id: pre_commit
         name: Run pre-commit
         if: github.event.action != 'closed' && github.event.pull_request.merged != true
         run: |
           pre-commit run --from-ref "${FROM_REF}" --to-ref "${TO_REF}" --show-diff-on-failure --color=always
         env:
-          FROM_REF: ${{ github.event.pull_request.base.sha }}
-          TO_REF: ${{ github.event.pull_request.head.sha }}
+          FROM_REF: ${{ steps.commit_range.outputs.from_ref }}
+          TO_REF: ${{ steps.commit_range.outputs.to_ref }}
       - name: Commit changes
         if: failure() && inputs.enable-commit-changes && github.event.pull_request.head.repo.full_name == github.repository
         run: |-


### PR DESCRIPTION
## Context

The reusable pre-commit workflows across all client repositories were failing when called from the datadog-api-spec repository due to a cross-repository SHA mismatch issue. The workflows were using `github.event.pull_request.base.sha` and `github.event.pull_request.head.sha` which refer to commits in the **spec repository**, but the workflows check out the **client repository**. This caused pre-commit to fail because these commit SHAs don't exist in the client repository.

This fix is essential for:
- **Cross-repository CI**: Enables spec repository to validate generated client code using reusable workflows
- **MergeQueue compatibility**: Required for the centralized CI management approach
- **Semantic correctness**: Pre-commit should check files changed in the branch, not arbitrary commit ranges from another repository

## Changes

### Modified Files
- **`datadog-api-client-typescript/.github/workflows/reusable-pre-commit.yml`**: Added merge-base commit range determination


## Tests

This will be tested by referencing this version of the workflow in a spec PR.
