### PR TITLE
Update minimum required version of form-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "buffer-from": "^1.1.2",
     "cross-fetch": "^3.1.5",
     "es6-promise": "^4.2.8",
-    "form-data": "^4.0.0",
+    "form-data": "^4.0.4",
     "loglevel": "^1.8.1",
     "pako": "^2.0.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2674,7 +2674,7 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.1.3"
 
-form-data@^4.0.0:
+form-data@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
   integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==


### PR DESCRIPTION
Follow up to: https://github.com/DataDog/datadog-api-client-typescript/pull/2558

Lets bump the form-data min version to 4.0.4