### PR TITLE
Bump form-data to 4.0.4

### DIFF
--- a/packages/datadog-api-client/package.json
+++ b/packages/datadog-api-client/package.json
@@ -35,7 +35,7 @@
     "buffer-from": "^1.1.2",
     "cross-fetch": "^3.1.5",
     "es6-promise": "^4.2.8",
-    "form-data": "^4.0.0",
+    "form-data": "^4.0.4",
     "loglevel": "^1.8.1",
     "pako": "^2.0.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,7 +1082,7 @@ __metadata:
     buffer-from: "npm:^1.1.2"
     cross-fetch: "npm:^3.1.5"
     es6-promise: "npm:^4.2.8"
-    form-data: "npm:^4.0.0"
+    form-data: "npm:^4.0.4"
     loglevel: "npm:^1.8.1"
     pako: "npm:^2.0.4"
     typescript: "npm:5.8.3"
@@ -3128,15 +3128,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.0":
-  version: 4.0.2
-  resolution: "form-data@npm:4.0.2"
+"form-data@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "form-data@npm:4.0.4"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.2"
     mime-types: "npm:^2.1.12"
-  checksum: 10c0/e534b0cf025c831a0929bf4b9bbe1a9a6b03e273a8161f9947286b9b13bf8fb279c6944aae0070c4c311100c6d6dbb815cd955dc217728caf73fad8dc5b8ee9c
+  checksum: 10c0/373525a9a034b9d57073e55eab79e501a714ffac02e7a9b01be1c820780652b16e4101819785e1e18f8d98f0aee866cc654d660a435c378e16a72f2e7cac9695
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fix `CVE-2025-7783` by bumping the form-data version to 4.0.4