### PR TITLE
Prepare for `v2` branch release

### DIFF
--- a/packages/datadog-api-client/CHANGELOG.md
+++ b/packages/datadog-api-client/CHANGELOG.md
@@ -5,8 +5,4 @@
 ### Security
 * Bump form-data to 4.0.4 [#2853](https://github.com/DataDog/datadog-api-client-typescript/pull/2853)
 
-### Added
-* Documenting the new Flaky Test Management API endpoint for public beta [#2787](https://github.com/DataDog/datadog-api-client-typescript/pull/2787)
-* Add Cross Org API to Open API specs [#2758](https://github.com/DataDog/datadog-api-client-typescript/pull/2758)
-
 ## 2.0.0-beta.1/2025-06-05

--- a/packages/datadog-api-client/CHANGELOG.md
+++ b/packages/datadog-api-client/CHANGELOG.md
@@ -1,3 +1,12 @@
 # CHANGELOG
 
+## 2.0.0-beta.2/2025-10-02
+
+### Security
+* Bump form-data to 4.0.4 [#2853](https://github.com/DataDog/datadog-api-client-typescript/pull/2853)
+
+### Added
+* Documenting the new Flaky Test Management API endpoint for public beta [#2787](https://github.com/DataDog/datadog-api-client-typescript/pull/2787)
+* Add Cross Org API to Open API specs [#2758](https://github.com/DataDog/datadog-api-client-typescript/pull/2758)
+
 ## 2.0.0-beta.1/2025-06-05

--- a/packages/datadog-api-client/package.json
+++ b/packages/datadog-api-client/package.json
@@ -45,6 +45,6 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "packageManager": "yarn@4.9.1"
 }


### PR DESCRIPTION
Updates versions and adds changelog entries for the `v2` branch release.