### PR TITLE
CRED-2148: Add PAT auth support to TypeScript API client

### DIFF
--- a/packages/datadog-api-client-common/auth.ts
+++ b/packages/datadog-api-client-common/auth.ts
@@ -81,10 +81,26 @@ export class AppKeyAuthAuthentication implements SecurityAuthentication {
   }
 }
 
+/**
+ * Applies bearer token authentication to the request context.
+ */
+export class BearerAuthAuthentication implements SecurityAuthentication {
+  public constructor(private token: string) {}
+
+  public getName(): string {
+    return "bearerAuth";
+  }
+
+  public applySecurityAuthentication(context: RequestContext): void {
+    context.setHeaderParam("Authorization", "Bearer " + this.token);
+  }
+}
+
 export type AuthMethods = {
   AuthZ?: SecurityAuthentication;
   apiKeyAuth?: SecurityAuthentication;
   appKeyAuth?: SecurityAuthentication;
+  bearerAuth?: SecurityAuthentication;
 };
 
 export type ApiKeyConfiguration = string;
@@ -96,6 +112,7 @@ export type AuthMethodsConfiguration = {
   AuthZ?: OAuth2Configuration;
   apiKeyAuth?: ApiKeyConfiguration;
   appKeyAuth?: ApiKeyConfiguration;
+  bearerAuth?: ApiKeyConfiguration;
 };
 
 /**
@@ -126,6 +143,12 @@ export function configureAuthMethods(
   if (config["appKeyAuth"]) {
     authMethods["appKeyAuth"] = new AppKeyAuthAuthentication(
       config["appKeyAuth"]
+    );
+  }
+
+  if (config["bearerAuth"]) {
+    authMethods["bearerAuth"] = new BearerAuthAuthentication(
+      config["bearerAuth"]
     );
   }
 

--- a/packages/datadog-api-client-common/configuration.ts
+++ b/packages/datadog-api-client-common/configuration.ts
@@ -208,6 +208,14 @@ export function createConfiguration(
   ) {
     authMethods["appKeyAuth"] = process.env.DD_APP_KEY;
   }
+  if (
+    !("bearerAuth" in authMethods) &&
+    typeof process !== "undefined" &&
+    process.env &&
+    process.env.DD_BEARER_TOKEN
+  ) {
+    authMethods["bearerAuth"] = process.env.DD_BEARER_TOKEN;
+  }
 
   const configuration = new Configuration(
     conf.baseServer,
@@ -484,6 +492,10 @@ export function applySecurityAuthentication<
   requestContext: RequestContext,
   authMethods: AuthMethodKey[]
 ): void {
+  if (conf.authMethods["bearerAuth"]) {
+    conf.authMethods["bearerAuth"].applySecurityAuthentication(requestContext);
+  }
+
   for (const authMethodName of authMethods) {
     const authMethod = conf.authMethods[authMethodName];
     if (authMethod) {

--- a/packages/datadog-api-client-common/http/isomorphic-fetch.ts
+++ b/packages/datadog-api-client-common/http/isomorphic-fetch.ts
@@ -180,6 +180,9 @@ export class IsomorphicFetchHttpLibrary implements HttpLibrary {
         "x"
       );
     }
+    if (headers["Authorization"]) {
+      headers["Authorization"] = headers["Authorization"].replace(/./g, "x");
+    }
 
     const headersJSON = JSON.stringify(headers, null, 2).replace(/\n/g, "\n\t");
     const method = request.getHttpMethod().toString();

--- a/tests/api/auth.test.ts
+++ b/tests/api/auth.test.ts
@@ -1,0 +1,151 @@
+import {
+  RequestContext,
+  HttpMethod,
+} from "../../packages/datadog-api-client-common/";
+import {
+  BearerAuthAuthentication,
+  ApiKeyAuthAuthentication,
+  AppKeyAuthAuthentication,
+  configureAuthMethods,
+} from "../../packages/datadog-api-client-common/auth";
+import {
+  createConfiguration,
+  applySecurityAuthentication,
+} from "../../packages/datadog-api-client-common/configuration";
+
+describe("BearerAuthAuthentication", () => {
+  it("should set Authorization Bearer header", () => {
+    const auth = new BearerAuthAuthentication("ddpat_test_token_123");
+    const ctx = new RequestContext("https://example.com", HttpMethod.GET);
+    auth.applySecurityAuthentication(ctx);
+    expect(ctx.getHeaders()["Authorization"]).toBe(
+      "Bearer ddpat_test_token_123"
+    );
+  });
+
+  it("should return correct name", () => {
+    const auth = new BearerAuthAuthentication("token");
+    expect(auth.getName()).toBe("bearerAuth");
+  });
+});
+
+describe("configureAuthMethods", () => {
+  it("should configure bearerAuth when provided", () => {
+    const methods = configureAuthMethods({
+      bearerAuth: "ddpat_my_pat",
+    });
+    expect(methods.bearerAuth).toBeDefined();
+    expect(methods.bearerAuth!.getName()).toBe("bearerAuth");
+  });
+
+  it("should configure all auth methods together", () => {
+    const methods = configureAuthMethods({
+      apiKeyAuth: "api_key",
+      appKeyAuth: "app_key",
+      bearerAuth: "ddpat_pat",
+    });
+    expect(methods.apiKeyAuth).toBeDefined();
+    expect(methods.appKeyAuth).toBeDefined();
+    expect(methods.bearerAuth).toBeDefined();
+  });
+});
+
+describe("createConfiguration with bearer auth", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should read DD_BEARER_TOKEN env var", () => {
+    process.env.DD_BEARER_TOKEN = "ddpat_env_pat";
+    const config = createConfiguration();
+    expect(config.authMethods.bearerAuth).toBeDefined();
+  });
+
+  it("should not override explicit bearerAuth config", () => {
+    process.env.DD_BEARER_TOKEN = "ddpat_env_pat";
+    const config = createConfiguration({
+      authMethods: {
+        bearerAuth: "ddpat_explicit_pat",
+      },
+    });
+    const ctx = new RequestContext("https://example.com", HttpMethod.GET);
+    config.authMethods.bearerAuth!.applySecurityAuthentication(ctx);
+    expect(ctx.getHeaders()["Authorization"]).toBe(
+      "Bearer ddpat_explicit_pat"
+    );
+  });
+});
+
+describe("applySecurityAuthentication with bearer auth", () => {
+  it("should send Bearer header when only bearerAuth is configured", () => {
+    const config = createConfiguration({
+      authMethods: {
+        bearerAuth: "ddpat_test_pat",
+      },
+    });
+    const ctx = new RequestContext("https://example.com", HttpMethod.GET);
+    applySecurityAuthentication(config, ctx, [
+      "apiKeyAuth",
+      "appKeyAuth",
+      "AuthZ",
+    ]);
+    expect(ctx.getHeaders()["Authorization"]).toBe("Bearer ddpat_test_pat");
+    expect(ctx.getHeaders()["DD-API-KEY"]).toBeUndefined();
+    expect(ctx.getHeaders()["DD-APPLICATION-KEY"]).toBeUndefined();
+  });
+
+  it("should send all auth headers when all are configured", () => {
+    const config = createConfiguration({
+      authMethods: {
+        apiKeyAuth: "test_api_key",
+        appKeyAuth: "test_app_key",
+        bearerAuth: "ddpat_test_pat",
+      },
+    });
+    const ctx = new RequestContext("https://example.com", HttpMethod.GET);
+    applySecurityAuthentication(config, ctx, [
+      "apiKeyAuth",
+      "appKeyAuth",
+      "AuthZ",
+    ]);
+    expect(ctx.getHeaders()["Authorization"]).toBe("Bearer ddpat_test_pat");
+    expect(ctx.getHeaders()["DD-API-KEY"]).toBe("test_api_key");
+    expect(ctx.getHeaders()["DD-APPLICATION-KEY"]).toBe("test_app_key");
+  });
+
+  it("should use API key + app key when bearerAuth is not configured", () => {
+    const config = createConfiguration({
+      authMethods: {
+        apiKeyAuth: "test_api_key",
+        appKeyAuth: "test_app_key",
+      },
+    });
+    const ctx = new RequestContext("https://example.com", HttpMethod.GET);
+    applySecurityAuthentication(config, ctx, [
+      "apiKeyAuth",
+      "appKeyAuth",
+      "AuthZ",
+    ]);
+    expect(ctx.getHeaders()["DD-API-KEY"]).toBe("test_api_key");
+    expect(ctx.getHeaders()["DD-APPLICATION-KEY"]).toBe("test_app_key");
+    expect(ctx.getHeaders()["Authorization"]).toBeUndefined();
+  });
+
+  it("should use only API key when only apiKeyAuth is required and no bearer auth", () => {
+    const config = createConfiguration({
+      authMethods: {
+        apiKeyAuth: "test_api_key",
+      },
+    });
+    const ctx = new RequestContext("https://example.com", HttpMethod.GET);
+    applySecurityAuthentication(config, ctx, ["apiKeyAuth"]);
+    expect(ctx.getHeaders()["DD-API-KEY"]).toBe("test_api_key");
+    expect(ctx.getHeaders()["Authorization"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## PR Stack

### API Client Libraries (closed)
All client libraries except Rust already support PATs via the existing OAuth/AuthZ code path. No new changes were needed.

- ~~**Go**: https://github.com/DataDog/datadog-api-client-go/pull/3764 — CRED-2147~~ — PATs work via existing OAuth code path
- ~~**Python**: https://github.com/DataDog/datadog-api-client-python/pull/3243 — CRED-2146~~ — PATs work via existing OAuth code path
- ~~**TypeScript**: https://github.com/DataDog/datadog-api-client-typescript/pull/3588 — CRED-2148~~ — PATs work via existing OAuth code path
- ~~**TypeScript v2**: https://github.com/DataDog/datadog-api-client-typescript/pull/3610 — CRED-2148~~ — PATs work via existing OAuth code path
- ~~**Java**: https://github.com/DataDog/datadog-api-client-java/pull/3555 — CRED-2149~~ — PATs work via existing OAuth code path
- ~~**Ruby**: https://github.com/DataDog/datadog-api-client-ruby/pull/3058 — CRED-2151~~ — PATs work via existing OAuth code path

**Rust**: The Rust client generator does not support OAuth/AuthZ, so PATs cannot be used through the client library today. When OAuth/AuthZ support is added to the Rust generator in the future ([#1438](https://github.com/DataDog/datadog-api-client-rust/pull/1438) has the approach), PATs will work automatically.

### OpenAPI Spec Changes
- https://github.com/DataDog/datadog-api-spec/pull/5164 — CRED-2275: Add PAT/SAT management API endpoints

---

## Closing Note

**This PR is being closed.** PATs can be passed in using the existing OAuth (AuthZ) code path -- no new client library changes are needed. See the test program demonstrating this:
- [test_program.ts](https://github.com/DataDog/datadog-api-client-typescript/blob/beb372330b25/test_program.ts)