### PR TITLE
CRED-2148: Add PAT auth support to TypeScript v2 API client

### DIFF
--- a/packages/datadog-api-client/src/auth.ts
+++ b/packages/datadog-api-client/src/auth.ts
@@ -81,10 +81,26 @@ export class AppKeyAuthAuthentication implements SecurityAuthentication {
   }
 }
 
+/**
+ * Applies bearer token authentication to the request context.
+ */
+export class BearerAuthAuthentication implements SecurityAuthentication {
+  public constructor(private token: string) {}
+
+  public getName(): string {
+    return "bearerAuth";
+  }
+
+  public applySecurityAuthentication(context: RequestContext): void {
+    context.setHeaderParam("Authorization", "Bearer " + this.token);
+  }
+}
+
 export type AuthMethods = {
   AuthZ?: SecurityAuthentication;
   apiKeyAuth?: SecurityAuthentication;
   appKeyAuth?: SecurityAuthentication;
+  bearerAuth?: SecurityAuthentication;
 };
 
 export type ApiKeyConfiguration = string;
@@ -96,6 +112,7 @@ export type AuthMethodsConfiguration = {
   AuthZ?: OAuth2Configuration;
   apiKeyAuth?: ApiKeyConfiguration;
   appKeyAuth?: ApiKeyConfiguration;
+  bearerAuth?: ApiKeyConfiguration;
 };
 
 /**
@@ -126,6 +143,12 @@ export function configureAuthMethods(
   if (config["appKeyAuth"]) {
     authMethods["appKeyAuth"] = new AppKeyAuthAuthentication(
       config["appKeyAuth"],
+    );
+  }
+
+  if (config["bearerAuth"]) {
+    authMethods["bearerAuth"] = new BearerAuthAuthentication(
+      config["bearerAuth"],
     );
   }
 

--- a/packages/datadog-api-client/src/configuration.ts
+++ b/packages/datadog-api-client/src/configuration.ts
@@ -218,6 +218,14 @@ export function createConfiguration(
   ) {
     authMethods["appKeyAuth"] = process.env.DD_APP_KEY;
   }
+  if (
+    !("bearerAuth" in authMethods) &&
+    typeof process !== "undefined" &&
+    process.env &&
+    process.env.DD_BEARER_TOKEN
+  ) {
+    authMethods["bearerAuth"] = process.env.DD_BEARER_TOKEN;
+  }
 
   const configuration = new Configuration(
     conf.baseServer,
@@ -254,6 +262,10 @@ export function applySecurityAuthentication<
   requestContext: RequestContext,
   authMethods: AuthMethodKey[],
 ): void {
+  if (conf.authMethods["bearerAuth"]) {
+    conf.authMethods["bearerAuth"].applySecurityAuthentication(requestContext);
+  }
+
   for (const authMethodName of authMethods) {
     const authMethod = conf.authMethods[authMethodName];
     if (authMethod) {

--- a/packages/datadog-api-client/src/http/isomorphic-fetch.ts
+++ b/packages/datadog-api-client/src/http/isomorphic-fetch.ts
@@ -180,6 +180,9 @@ export class IsomorphicFetchHttpLibrary implements HttpLibrary {
         "x",
       );
     }
+    if (headers["Authorization"]) {
+      headers["Authorization"] = headers["Authorization"].replace(/./g, "x");
+    }
 
     const headersJSON = JSON.stringify(headers, null, 2).replace(/\n/g, "\n\t");
     const method = request.getHttpMethod().toString();


### PR DESCRIPTION
## PR Stack

### API Client Libraries (closed)
All client libraries except Rust already support PATs via the existing OAuth/AuthZ code path. No new changes were needed.

- ~~**Go**: https://github.com/DataDog/datadog-api-client-go/pull/3764 — CRED-2147~~ — PATs work via existing OAuth code path
- ~~**Python**: https://github.com/DataDog/datadog-api-client-python/pull/3243 — CRED-2146~~ — PATs work via existing OAuth code path
- ~~**TypeScript**: https://github.com/DataDog/datadog-api-client-typescript/pull/3588 — CRED-2148~~ — PATs work via existing OAuth code path
- ~~**TypeScript v2**: https://github.com/DataDog/datadog-api-client-typescript/pull/3610 — CRED-2148~~ — PATs work via existing OAuth code path
- ~~**Java**: https://github.com/DataDog/datadog-api-client-java/pull/3555 — CRED-2149~~ — PATs work via existing OAuth code path
- ~~**Ruby**: https://github.com/DataDog/datadog-api-client-ruby/pull/3058 — CRED-2151~~ — PATs work via existing OAuth code path

**Rust**: The Rust client generator does not support OAuth/AuthZ, so PATs cannot be used through the client library today. When OAuth/AuthZ support is added to the Rust generator in the future ([#1438](https://github.com/DataDog/datadog-api-client-rust/pull/1438) has the approach), PATs will work automatically.

### OpenAPI Spec Changes
- https://github.com/DataDog/datadog-api-spec/pull/5164 — CRED-2275: Add PAT/SAT management API endpoints

---

## Closing Note

**This PR is being closed.** PATs can be passed in using the existing OAuth (AuthZ) code path -- no new client library changes are needed. See the test program demonstrating this:
- [test_program.ts](https://github.com/DataDog/datadog-api-client-typescript/blob/f2d8bf5b7722/test_program.ts)