### PR TITLE
fix(formatter): use primitive type instead of schema name in get_response_type (AAWF-1199)

### DIFF
--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -451,6 +451,12 @@ def get_response_type(schema, version):
             name = simple_type(nested_schema)
         api_response_type = f"{name}[]"
     else:
+        primitive = simple_type(response_schema)
         name = schema_name(response_schema)
-        api_response_type = f"{version}.{name}" if name else simple_type(response_schema)
+        if name and not primitive:
+            api_response_type = f"{version}.{name}"
+        else:
+            # Named primitive schemas (e.g. type: string) don't produce a class —
+            # use the primitive type directly.
+            api_response_type = primitive
     return api_response_type


### PR DESCRIPTION
## Context

When a named component schema has a primitive type (e.g. `type: string`), `get_response_type()` used `schema_name()` directly — emitting the schema name as a versioned type (e.g. `v2.ConvertCatalogEntityResponse`). But no type is generated for primitive schemas, causing a compile error in generated examples.

Example: `ConvertCatalogEntityResponse: {type: string}` caused the example to reference `v2.ConvertCatalogEntityResponse` which doesn't exist.

## Fix

Check `simple_type()` first — if the schema resolves to a primitive (`string`, `number`, etc.), use that type directly. Consistent with how `type_to_typescript()` already guards against this case.

## Test plan

- [ ] Generated examples for operations with primitive response schemas use the primitive type directly instead of a missing type reference