### PR TITLE
Fix "does not have field" assertion to accept undefined

### DIFF
--- a/features/step_definitions/request_steps.ts
+++ b/features/step_definitions/request_steps.ts
@@ -307,7 +307,7 @@ Then(
 Then(
   "the response {string} does not have field {string}",
   function (this: World, responsePath: string, field: string) {
-    expect(pathLookup(this.response, responsePath)).to.not.have.property(field.toAttributeName());
+    expect(pathLookup(this.response, responsePath)[field.toAttributeName()]).to.be.undefined;
   }
 );
 


### PR DESCRIPTION
## Summary

- `ObjectSerializer.deserialize()` always assigns `instance[attr] = undefined` for optional fields absent from the JSON response, so the property key exists on the object even when the field was not present in JSON
- Chai's `.not.have.property()` uses `hasOwnProperty()`, which returns `true` for `undefined`-valued keys, causing the `"does not have field"` step to fail for any optional model field that is absent from the API response
- Fix: assert `.to.be.undefined` on the value instead of checking key non-existence — semantically identical for JSON deserialization, but tolerates the way `ObjectSerializer` initialises optional fields

## Test plan

- [x] Ran full test suite (`./run-tests.sh`) — 1418 scenarios passed, 0 failed
- [x] 17 unit tests passed across 4 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)