### PR TITLE
AAWF-694: Add dd-octo-sts trust policy for v2 branch releases

### DIFF
--- a/.github/chainguard/self.github.release.v2.sts.yaml
+++ b/.github/chainguard/self.github.release.v2.sts.yaml
@@ -1,0 +1,14 @@
+# Trust policy for creating releases on v2 branch
+# Restricted to v2 branch (protected ref) for security
+# Will be called in release.yml
+issuer: https://token.actions.githubusercontent.com
+subject: repo:DataDog/datadog-api-client-typescript:pull_request
+
+claim_pattern:
+  event_name: pull_request
+  job_workflow_ref: DataDog/datadog-api-client-typescript/\.github/workflows/release\.yml@refs/heads/v2
+  repository: DataDog/datadog-api-client-typescript
+  ref: refs/heads/v2
+
+permissions:
+  contents: write


### PR DESCRIPTION
## Summary

- Add missing `self.github.release.v2` trust policy for dd-octo-sts
- The v2 branch `release.yml` references this policy but it didn't exist, causing split package releases to fail with `unable to find trust policy for "self.github.release.v2"`

## Context

Follow-up to #3949 (OIDC migration). The legacy package release on master works, but the split package release from the v2 branch fails because the dd-octo-sts trust policy was never created for v2.

## Test plan

- [ ] Merge this PR
- [ ] Re-trigger split package release via `prepare_release` with `generators: typescript_split_package`
- [ ] Verify sub-packages publish to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)