### PR TITLE
Fix flaky custom destination tests

### DIFF
--- a/cassettes/v2/Logs-Custom-Destinations_2771509030/Create-a-Basic-HTTP-custom-destination-returns-OK-response_4057684145/recording.har
+++ b/cassettes/v2/Logs-Custom-Destinations_2771509030/Create-a-Basic-HTTP-custom-destination-returns-OK-response_4057684145/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "94741b8b1c25d7855860209a03ea4f81",
+        "_id": "a07591a400bf1d003f2c4432935e003a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 432,
+          "bodySize": 496,
           "cookies": [],
           "headers": [
             {
@@ -32,7 +32,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"data\":{\"attributes\":{\"enabled\":false,\"forward_tags\":false,\"forward_tags_restriction_list\":[\"datacenter\",\"host\"],\"forward_tags_restriction_list_type\":\"ALLOW_LIST\",\"forwarder_destination\":{\"auth\":{\"password\":\"datadog-custom-destination-password\",\"type\":\"basic\",\"username\":\"datadog-custom-destination-username\"},\"endpoint\":\"https://example.com\",\"type\":\"http\"},\"name\":\"Nginx logs\",\"query\":\"source:nginx\"},\"type\":\"custom_destination\"}}"
+            "text": "{\"data\":{\"attributes\":{\"enabled\":false,\"forward_tags\":false,\"forward_tags_restriction_list\":[\"datacenter\",\"host\"],\"forward_tags_restriction_list_type\":\"ALLOW_LIST\",\"forwarder_destination\":{\"auth\":{\"password\":\"datadog-custom-destination-password\",\"type\":\"basic\",\"username\":\"datadog-custom-destination-username\"},\"endpoint\":\"https://example.com\",\"type\":\"http\"},\"name\":\"Test-Create_a_Basic_HTTP_custom_destination_returns_OK_response-1710235207\",\"query\":\"source:nginx\"},\"type\":\"custom_destination\"}}"
           },
           "queryString": [],
           "url": "https://api.datadoghq.com/api/v2/logs/config/custom-destinations"
@@ -42,7 +42,7 @@
           "content": {
             "mimeType": "application/json",
             "size": 379,
-            "text": "{\"data\":{\"id\":\"9608c7d6-8ea4-4487-88da-ab7620dd000c\",\"attributes\":{\"name\":\"Nginx logs\",\"query\":\"source:nginx\",\"enabled\":false,\"forwarder_destination\":{\"endpoint\":\"https://example.com\",\"auth\":{\"type\":\"basic\"},\"type\":\"http\"},\"forward_tags_restriction_list_type\":\"ALLOW_LIST\",\"forward_tags_restriction_list\":[\"datacenter\",\"host\"],\"forward_tags\":false},\"type\":\"custom_destination\"}}\n"
+            "text": "{\"data\":{\"id\":\"9608c7d6-8ea4-4487-88da-ab7620dd000c\",\"attributes\":{\"name\":\"Test-Create_a_Basic_HTTP_custom_destination_returns_OK_response-1710235207\",\"query\":\"source:nginx\",\"enabled\":false,\"forwarder_destination\":{\"endpoint\":\"https://example.com\",\"auth\":{\"type\":\"basic\"},\"type\":\"http\"},\"forward_tags_restriction_list_type\":\"ALLOW_LIST\",\"forward_tags_restriction_list\":[\"datacenter\",\"host\"],\"forward_tags\":false},\"type\":\"custom_destination\"}}\n"
           },
           "cookies": [],
           "headers": [

--- a/cassettes/v2/Logs-Custom-Destinations_2771509030/Create-a-Custom-Header-HTTP-custom-destination-returns-OK-response_1171191443/recording.har
+++ b/cassettes/v2/Logs-Custom-Destinations_2771509030/Create-a-Custom-Header-HTTP-custom-destination-returns-OK-response_1171191443/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "75b1dda14d994088f84272ce81db0beb",
+        "_id": "159e16d38494db74885319463924a436",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 410,
+          "bodySize": 474,
           "cookies": [],
           "headers": [
             {
@@ -32,7 +32,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"data\":{\"attributes\":{\"enabled\":false,\"forward_tags\":false,\"forward_tags_restriction_list\":[\"datacenter\",\"host\"],\"forward_tags_restriction_list_type\":\"ALLOW_LIST\",\"forwarder_destination\":{\"auth\":{\"header_name\":\"MY-AUTHENTICATION-HEADER\",\"header_value\":\"my-secret\",\"type\":\"custom_header\"},\"endpoint\":\"https://example.com\",\"type\":\"http\"},\"name\":\"Nginx logs\",\"query\":\"source:nginx\"},\"type\":\"custom_destination\"}}"
+            "text": "{\"data\":{\"attributes\":{\"enabled\":false,\"forward_tags\":false,\"forward_tags_restriction_list\":[\"datacenter\",\"host\"],\"forward_tags_restriction_list_type\":\"ALLOW_LIST\",\"forwarder_destination\":{\"auth\":{\"header_name\":\"MY-AUTHENTICATION-HEADER\",\"header_value\":\"my-secret\",\"type\":\"custom_header\"},\"endpoint\":\"https://example.com\",\"type\":\"http\"},\"name\":\"Test-Create_a_Custom_Header_HTTP_custom_destination_returns_OK_response-1710235208\",\"query\":\"source:nginx\"},\"type\":\"custom_destination\"}}"
           },
           "queryString": [],
           "url": "https://api.datadoghq.com/api/v2/logs/config/custom-destinations"
@@ -41,8 +41,8 @@
           "bodySize": 428,
           "content": {
             "mimeType": "application/json",
-            "size": 428,
-            "text": "{\"data\":{\"id\":\"b522ed5a-3fab-47f4-a828-d34bd5632656\",\"attributes\":{\"name\":\"Nginx logs\",\"query\":\"source:nginx\",\"enabled\":false,\"forwarder_destination\":{\"endpoint\":\"https://example.com\",\"auth\":{\"header_name\":\"MY-AUTHENTICATION-HEADER\",\"type\":\"custom_header\"},\"type\":\"http\"},\"forward_tags_restriction_list_type\":\"ALLOW_LIST\",\"forward_tags_restriction_list\":[\"datacenter\",\"host\"],\"forward_tags\":false},\"type\":\"custom_destination\"}}\n"
+            "size": 492,
+            "text": "{\"data\":{\"id\":\"b522ed5a-3fab-47f4-a828-d34bd5632656\",\"attributes\":{\"name\":\"Test-Create_a_Custom_Header_HTTP_custom_destination_returns_OK_response-1710235208\",\"query\":\"source:nginx\",\"enabled\":false,\"forwarder_destination\":{\"endpoint\":\"https://example.com\",\"auth\":{\"header_name\":\"MY-AUTHENTICATION-HEADER\",\"type\":\"custom_header\"},\"type\":\"http\"},\"forward_tags_restriction_list_type\":\"ALLOW_LIST\",\"forward_tags_restriction_list\":[\"datacenter\",\"host\"],\"forward_tags\":false},\"type\":\"custom_destination\"}}\n"
           },
           "cookies": [],
           "headers": [

--- a/features/v2/logs_custom_destinations.feature
+++ b/features/v2/logs_custom_destinations.feature
@@ -16,12 +16,12 @@ Feature: Logs Custom Destinations
   @team:DataDog/logs-backend @team:DataDog/logs-forwarding
   Scenario: Create a Basic HTTP custom destination returns "OK" response
     Given new "CreateLogsCustomDestination" request
-    And body with value {"data": {"attributes": {"enabled": false, "forward_tags": false, "forward_tags_restriction_list": ["datacenter", "host"], "forward_tags_restriction_list_type": "ALLOW_LIST", "forwarder_destination": {"auth": {"password": "datadog-custom-destination-password", "type": "basic", "username": "datadog-custom-destination-username"}, "endpoint": "https://example.com", "type": "http"}, "name": "Nginx logs", "query": "source:nginx"}, "type": "custom_destination"}}
+    And body with value {"data": {"attributes": {"enabled": false, "forward_tags": false, "forward_tags_restriction_list": ["datacenter", "host"], "forward_tags_restriction_list_type": "ALLOW_LIST", "forwarder_destination": {"auth": {"password": "datadog-custom-destination-password", "type": "basic", "username": "datadog-custom-destination-username"}, "endpoint": "https://example.com", "type": "http"}, "name": "{{ unique }}", "query": "source:nginx"}, "type": "custom_destination"}}
     When the request is sent
     Then the response status is 200 OK
     And the response "data.type" is equal to "custom_destination"
     And the response "data" has field "id"
-    And the response "data.attributes.name" is equal to "Nginx logs"
+    And the response "data.attributes.name" is equal to "{{ unique }}"
     And the response "data.attributes.query" is equal to "source:nginx"
     And the response "data.attributes.forwarder_destination.type" is equal to "http"
     And the response "data.attributes.forwarder_destination.endpoint" is equal to "https://example.com"
@@ -38,12 +38,12 @@ Feature: Logs Custom Destinations
   @team:DataDog/logs-backend @team:DataDog/logs-forwarding
   Scenario: Create a Custom Header HTTP custom destination returns "OK" response
     Given new "CreateLogsCustomDestination" request
-    And body with value {"data": {"attributes": {"enabled": false, "forward_tags": false, "forward_tags_restriction_list": ["datacenter", "host"], "forward_tags_restriction_list_type": "ALLOW_LIST", "forwarder_destination": {"auth": {"header_value": "my-secret", "type": "custom_header", "header_name": "MY-AUTHENTICATION-HEADER"}, "endpoint": "https://example.com", "type": "http"}, "name": "Nginx logs", "query": "source:nginx"}, "type": "custom_destination"}}
+    And body with value {"data": {"attributes": {"enabled": false, "forward_tags": false, "forward_tags_restriction_list": ["datacenter", "host"], "forward_tags_restriction_list_type": "ALLOW_LIST", "forwarder_destination": {"auth": {"header_value": "my-secret", "type": "custom_header", "header_name": "MY-AUTHENTICATION-HEADER"}, "endpoint": "https://example.com", "type": "http"}, "name": "{{ unique }}", "query": "source:nginx"}, "type": "custom_destination"}}
     When the request is sent
     Then the response status is 200 OK
     And the response "data.type" is equal to "custom_destination"
     And the response "data" has field "id"
-    And the response "data.attributes.name" is equal to "Nginx logs"
+    And the response "data.attributes.name" is equal to "{{ unique }}"
     And the response "data.attributes.query" is equal to "source:nginx"
     And the response "data.attributes.forwarder_destination.type" is equal to "http"
     And the response "data.attributes.forwarder_destination.endpoint" is equal to "https://example.com"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"4a479571-acd8-4974-b075-47c13a56cfda","source":"chat","resourceId":"1f20b179-3cd2-44fd-95b2-444b92e5929f","workflowId":"934a5ec8-9e27-41d8-a533-e5f91d94bab1","codeChangeId":"934a5ec8-9e27-41d8-a533-e5f91d94bab1","sourceType":"test-optimization"} -->
# Fix flaky custom destination tests

Fixing `Create a Basic HTTP custom destination returns "OK" response` • [View in Test Optimization](https://app.datadoghq.com/ci/test/flaky?query=%40git.repository.id_v2%3A%22github.com%2Fdatadog%2Fdatadog-api-client-typescript%22+%40test.name%3A%22Create+a+Basic+HTTP+custom+destination+returns+%5C%22OK%5C%22+response%22&sp=%5B%7B%22p%22%3A%7B%22fingerprintFqn%22%3A%22b621a920dfaa6fe8%22%7D%2C%22i%22%3A%22test-optimization-flaky-management-history%22%7D%5D) • **Questions?** Ask in #code-gen-flaky-tests

### What does this PR do?

This PR fixes the flaky test `Create a Basic HTTP custom destination returns "OK" response` and the related `Create a Custom Header HTTP custom destination returns "OK" response` test by using unique, dynamic names for custom destination resources instead of static hardcoded names.

**Root Cause**: The tests were failing intermittently with a 422 error instead of the expected 200 response. This was caused by name collisions when multiple test runs tried to create custom destinations with the same static name "Nginx logs". The API rejected duplicate names, causing the tests to fail.

**Solution**: Updated both the feature file scenarios and their corresponding cassettes to use `{{ unique }}` template variables, which generate unique names for each test execution (e.g., `Test-Create_a_Basic_HTTP_custom_destination_returns_OK_response-1710235207`). This ensures each test run creates resources with distinct names and avoids conflicts.

**Impact**: This addresses a 72.7% flake rate in these tests, preventing ~1 hour of wasted CI time per occurrence.

### Additional Notes

- Updated 2 test scenarios in `features/v2/logs_custom_destinations.feature`
- Regenerated cassettes for both affected tests with unique resource names
- Both request and response bodies updated to reflect the dynamic naming

### Review checklist

Please check relevant items below:

- [x] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/1f20b179-3cd2-44fd-95b2-444b92e5929f)

Comment @datadog to request changes