### PR TITLE
Allow cursor-based pagination to query extra page until collection is empty

### DIFF
--- a/cassettes/v2/Security-Monitoring_1187227211/List-security-findings-returns-OK-response-with-pagination_1895514683/recording.har
+++ b/cassettes/v2/Security-Monitoring_1187227211/List-security-findings-returns-OK-response-with-pagination_1895514683/recording.har
@@ -56,6 +56,58 @@
         },
         "startedDateTime": "2025-12-15T22:38:44.218Z",
         "time": 1437
+      },
+      {
+        "_id": "fc7fd3253a2f4250daec14274af16d9f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": -1,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "page[limit]",
+              "value": "5"
+            },
+            {
+              "name": "page[cursor]",
+              "value": "eyJhZnRlciI6IkF3QUFBWnNrS2tfNUZKWWZDd0FBQUJoQlduTnJTMnRmTlVGQlFqWkNNM3BmZVhadWJXNXhVMElBQUFBa1pqRTVZakkwTW1FdE5USmlaQzAwTldVd0xUZzRNREF0WW1ZeVlXSmlOR1k0TldRM0FBQUFMZyIsInZhbHVlcyI6WzE3NjU4MzgzMTE0MTcsIjIwMjUtMTItMTVUMjI6Mzg6MzEuNDE3WiIsMzQ1MzgyNjY3XX0="
+            }
+          ],
+          "url": "https://api.datadoghq.com/api/v2/security/findings?page%5Blimit%5D=5&page%5Bcursor%5D=eyJhZnRlciI6IkF3QUFBWnNrS2tfNUZKWWZDd0FBQUJoQlduTnJTMnRmTlVGQlFqWkNNM3BmZVhadWJXNXhVMElBQUFBa1pqRTVZakkwTW1FdE5USmlaQzAwTldVd0xUZzRNREF0WW1ZeVlXSmlOR1k0TldRM0FBQUFMZyIsInZhbHVlcyI6WzE3NjU4MzgzMTE0MTcsIjIwMjUtMTItMTVUMjI6Mzg6MzEuNDE3WiIsMzQ1MzgyNjY3XX0%3D"
+        },
+        "response": {
+          "bodySize": 11,
+          "content": {
+            "mimeType": "application/json",
+            "size": 11,
+            "text": "{\"data\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": -1,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-12-15T22:38:46.000Z",
+        "time": 0
       }
     ],
     "pages": [],

--- a/cassettes/v2/Security-Monitoring_1187227211/Search-security-findings-returns-OK-response-with-pagination_3585802019/recording.har
+++ b/cassettes/v2/Security-Monitoring_1187227211/Search-security-findings-returns-OK-response-with-pagination_3585802019/recording.har
@@ -59,6 +59,58 @@
         },
         "startedDateTime": "2025-12-15T22:44:41.945Z",
         "time": 1040
+      },
+      {
+        "_id": "934909a865fc8e601bbbefee691c8cfd",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 356,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": -1,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "text": "{\"data\": {\"attributes\": {\"filter\": \"@severity:(critical OR high)\", \"page\": {\"limit\": 1, \"cursor\": \"eyJhZnRlciI6IkF3QUFBWnNrTDh2VTlLUDFyQUFBQUJoQlduTnJURGgyVlVGQlF6QnVTVVJUUTBwbk5HbE9jSE1BQUFBa1pqRTVZakkwTW1ZdFpEUXhOeTAwWW1GbExUZ3haRFl0WkRZME5EazFNelE0TkRabEFBQUg0ZyIsInZhbHVlcyI6WzE3NjU4Mzg2NzA4MDQsIjIwMjUtMTItMTVUMjI6NDQ6MzAuODA0WiIsLTE5MDU4MTMzMl19\"}}}}"
+          },
+          "queryString": [],
+          "url": "https://api.datadoghq.com/api/v2/security/findings/search"
+        },
+        "response": {
+          "bodySize": 11,
+          "content": {
+            "mimeType": "application/json",
+            "size": 11,
+            "text": "{\"data\":[]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": -1,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2025-12-15T22:38:46.000Z",
+        "time": 0
       }
     ],
     "pages": [],

--- a/packages/datadog-api-client-v2/apis/AuditApi.ts
+++ b/packages/datadog-api-client-v2/apis/AuditApi.ts
@@ -383,7 +383,7 @@ export class AuditApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;
@@ -467,7 +467,7 @@ export class AuditApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;

--- a/packages/datadog-api-client-v2/apis/CIVisibilityPipelinesApi.ts
+++ b/packages/datadog-api-client-v2/apis/CIVisibilityPipelinesApi.ts
@@ -667,7 +667,7 @@ export class CIVisibilityPipelinesApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;
@@ -752,7 +752,7 @@ export class CIVisibilityPipelinesApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;

--- a/packages/datadog-api-client-v2/apis/CIVisibilityTestsApi.ts
+++ b/packages/datadog-api-client-v2/apis/CIVisibilityTestsApi.ts
@@ -524,7 +524,7 @@ export class CIVisibilityTestsApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;
@@ -606,7 +606,7 @@ export class CIVisibilityTestsApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;

--- a/packages/datadog-api-client-v2/apis/ContainerImagesApi.ts
+++ b/packages/datadog-api-client-v2/apis/ContainerImagesApi.ts
@@ -258,7 +258,7 @@ export class ContainerImagesApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;

--- a/packages/datadog-api-client-v2/apis/ContainersApi.ts
+++ b/packages/datadog-api-client-v2/apis/ContainersApi.ts
@@ -257,7 +257,7 @@ export class ContainersApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;

--- a/packages/datadog-api-client-v2/apis/EventsApi.ts
+++ b/packages/datadog-api-client-v2/apis/EventsApi.ts
@@ -671,7 +671,7 @@ export class EventsApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;
@@ -753,7 +753,7 @@ export class EventsApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;

--- a/packages/datadog-api-client-v2/apis/LogsApi.ts
+++ b/packages/datadog-api-client-v2/apis/LogsApi.ts
@@ -689,7 +689,7 @@ export class LogsApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;
@@ -786,7 +786,7 @@ export class LogsApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;

--- a/packages/datadog-api-client-v2/apis/MetricsApi.ts
+++ b/packages/datadog-api-client-v2/apis/MetricsApi.ts
@@ -2450,7 +2450,7 @@ export class MetricsApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;

--- a/packages/datadog-api-client-v2/apis/ProcessesApi.ts
+++ b/packages/datadog-api-client-v2/apis/ProcessesApi.ts
@@ -276,7 +276,7 @@ export class ProcessesApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;

--- a/packages/datadog-api-client-v2/apis/RUMApi.ts
+++ b/packages/datadog-api-client-v2/apis/RUMApi.ts
@@ -1108,7 +1108,7 @@ export class RUMApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;
@@ -1190,7 +1190,7 @@ export class RUMApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;

--- a/packages/datadog-api-client-v2/apis/SecurityMonitoringApi.ts
+++ b/packages/datadog-api-client-v2/apis/SecurityMonitoringApi.ts
@@ -14807,7 +14807,7 @@ export class SecurityMonitoringApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;
@@ -15054,7 +15054,7 @@ export class SecurityMonitoringApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;
@@ -15220,7 +15220,7 @@ export class SecurityMonitoringApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;
@@ -15653,7 +15653,7 @@ export class SecurityMonitoringApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;
@@ -15760,7 +15760,7 @@ export class SecurityMonitoringApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;

--- a/packages/datadog-api-client-v2/apis/SpansApi.ts
+++ b/packages/datadog-api-client-v2/apis/SpansApi.ts
@@ -538,7 +538,7 @@ export class SpansApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;
@@ -627,7 +627,7 @@ export class SpansApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;

--- a/packages/datadog-api-client-v2/apis/TestOptimizationApi.ts
+++ b/packages/datadog-api-client-v2/apis/TestOptimizationApi.ts
@@ -997,7 +997,7 @@ export class TestOptimizationApi {
       for (const item of results) {
         yield item;
       }
-      if (results.length < pageSize) {
+      if (results.length === 0) {
         break;
       }
       const cursorMeta = response.meta;


### PR DESCRIPTION
### What does this PR do?

Mirrors [datadog-api-client-java#3790](https://github.com/DataDog/datadog-api-client-java/pull/3790) and [datadog-api-client-go#3769](https://github.com/DataDog/datadog-api-client-go/pull/3769) for the TypeScript client.

Cursor-based paginators now keep querying until the response collection is empty (`results.length === 0`), instead of stopping early when a page returns fewer items than the requested limit (`results.length < pageSize`). This prevents missed items when a page happens to return fewer results than the limit without being the last page. Page-offset and page-number paginations keep their existing behavior.

- 24 cursor-based `WithPagination` methods updated across 13 v2 API files (Audit, CI Visibility Pipelines/Tests, Container Images, Containers, Events, Logs, Metrics, Processes, RUM, Security Monitoring, Spans, Test Optimization).
- 21 offset/page-number-based methods remain unchanged.
- Added trailing empty-response cassettes for `ListSecurityFindings` and `SearchSecurityFindings` pagination tests.

### Additional Notes

The supporting cassettes (extra trailing `{"data":[]}` response) for most cursor-based endpoints were already added previously. Only the two Security Findings cassettes needed new empty-response entries.

### Review checklist

Please check relevant items below:

- [x] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)