### PR TITLE
[CRED-2625] Re-apply Authorization header redaction in debug logRequest

### DIFF
--- a/packages/datadog-api-client-common/http/isomorphic-fetch.ts
+++ b/packages/datadog-api-client-common/http/isomorphic-fetch.ts
@@ -171,14 +171,17 @@ export class IsomorphicFetchHttpLibrary implements HttpLibrary {
     for (const header in originalHeaders) {
       headers[header] = originalHeaders[header];
     }
-    if (headers["DD-API-KEY"]) {
-      headers["DD-API-KEY"] = headers["DD-API-KEY"].replace(/./g, "x");
-    }
-    if (headers["DD-APPLICATION-KEY"]) {
-      headers["DD-APPLICATION-KEY"] = headers["DD-APPLICATION-KEY"].replace(
-        /./g,
-        "x"
-      );
+    // Mask credential headers before serializing for the debug log.
+    // Authorization carries Bearer tokens (delegated tokens, PATs). See CRED-2625.
+    const headersToRedact = [
+      "DD-API-KEY",
+      "DD-APPLICATION-KEY",
+      "Authorization",
+    ];
+    for (const header of headersToRedact) {
+      if (headers[header]) {
+        headers[header] = headers[header].replace(/./g, "x");
+      }
     }
 
     const headersJSON = JSON.stringify(headers, null, 2).replace(/\n/g, "\n\t");

--- a/tests/api/log-redaction.test.ts
+++ b/tests/api/log-redaction.test.ts
@@ -1,0 +1,47 @@
+import { IsomorphicFetchHttpLibrary } from "../../packages/datadog-api-client-common/http/isomorphic-fetch";
+import {
+  HttpMethod,
+  RequestContext,
+} from "../../packages/datadog-api-client-common/http/http";
+import { logger } from "../../logger";
+
+// TestLogRequestRedactsAuthorization verifies that when debug logging is on,
+// the IsomorphicFetchHttpLibrary masks the Authorization header (Bearer
+// tokens — delegated tokens, PATs) before sending the request log line to
+// the logger. Without this, callers running with debug logging and access-
+// token auth leak the bearer to stderr / CI artifacts / log shippers.
+// See CRED-2625.
+test("logRequest masks Authorization Bearer token", () => {
+  const debugMessages: string[] = [];
+  const originalDebug = logger.debug.bind(logger);
+  logger.debug = (...args: unknown[]) => {
+    debugMessages.push(args.map(String).join(""));
+  };
+
+  try {
+    const http = new IsomorphicFetchHttpLibrary();
+    http.debug = true;
+
+    const ctx = new RequestContext("https://api.example.com/ping", HttpMethod.GET);
+    ctx.setHeaderParam("DD-API-KEY", "api-key-secret-value");
+    ctx.setHeaderParam("DD-APPLICATION-KEY", "app-key-secret-value");
+    ctx.setHeaderParam("Authorization", "Bearer ddpat_supersecret_should_not_leak");
+
+    // logRequest is private; exercise it indirectly by reaching through the
+    // class. Acceptable in a test file since the redaction surface is what
+    // we're asserting on, not the public send() pipeline.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (http as any).logRequest(ctx);
+
+    const joined = debugMessages.join("\n");
+    expect(joined).not.toContain("api-key-secret-value");
+    expect(joined).not.toContain("app-key-secret-value");
+    expect(joined).not.toContain("ddpat_supersecret_should_not_leak");
+    // Each redacted value is replaced with `x` repeated to its original length.
+    expect(joined).toMatch(/DD-API-KEY":\s*"x+"/);
+    expect(joined).toMatch(/DD-APPLICATION-KEY":\s*"x+"/);
+    expect(joined).toMatch(/Authorization":\s*"x+"/);
+  } finally {
+    logger.debug = originalDebug;
+  }
+});


### PR DESCRIPTION
## Description

Re-applies the fix from #4168 that was reverted by #4207. The original revert was a misdirected unblock: the test was failing on a separate, regen-only branch where the production-code edit had been silently stripped out by the spec-sync regen, while the new test file persisted. That looked like a broken fix; it was actually a template-vs-generated-file mismatch.

Investigation summary:

- #4168's CI: all jobs green, including `test (16, ubuntu-latest)` and `test (18, ubuntu-latest)`. The fix worked.
- After #4168 merged, a separately auto-regenerated PR (#4156, branch `datadog-api-spec/generated/5684`) ran tests at commit `659162b798e7`. Diff of that commit vs its branch base (`e4ed866f0f80`, which already contained #4168) shows `packages/datadog-api-client-common/http/isomorphic-fetch.ts` with `+8/-11` — the *exact inverse* of #4168's `+11/-8`. The regen reverted that file from template.
- The branch retained the new `tests/api/log-redaction.test.ts` (a hand-written test, untouched by regen). With the production code reverted and the test still present, the test correctly fails — but the failure isn't a "broken fix", it's a "missing template change".
- `isomorphic-fetch.ts` is not regenerated from the in-repo `.generator/` directory (which only holds `example.j2`); it's regenerated from templates in the separate private repo `DataDog/datadog-api-client-generator`, by the `api-clients-generation-pipeline[bot]` GitHub App. Both `src/.../typescript/templates/common_package/http/isomorphic-fetch.ts.j2` and `src/.../typescript_unified/templates/http/isomorphic-fetch.ts.j2` had only the DD-API-KEY / DD-APPLICATION-KEY redaction, never Authorization.

A companion patch against `datadog-api-client-generator` updates both templates so this fix is durable. Once that lands, the next regen reproduces the generated file in this PR byte-for-byte.

## Changes

- `packages/datadog-api-client-common/http/isomorphic-fetch.ts`: restores the `headersToRedact` array (DD-API-KEY, DD-APPLICATION-KEY, Authorization) and the loop that masks each value with `x` repeated to its original length.
- `tests/api/log-redaction.test.ts`: restored. Drives `logRequest` directly with a captured `logger.debug`, asserts the raw bearer string does not appear in the joined output, and asserts Authorization is masked to an `x+` run.

## Cross-language status

- `datadog-api-client-go` #4098: merged. Templates and generated file both updated in one PR (templates are local to the SDK repo there, so the issue did not arise).
- `datadog-api-client-ruby` #3340: merged. Same — local templates updated alongside the generated `.rb`.
- `datadog-api-client-java`: still has no header redaction in `LoggingFeature.PAYLOAD_ANY`; tracked separately.
- `datadog-api-client-python`: no equivalent debug code path; no fix needed.

## Testing

- [x] Local: this PR is a clean `git revert` of #4207, so the diff vs `master` is identical to #4168, which passed CI when originally merged.
- [ ] CI: must be green here (`test (16)`, `test (18)`) before merge.
- [ ] **Merge order:** the companion `datadog-api-client-generator` PR should land first (or together). Without it, the next spec-sync regen will strip these changes again and we will repeat the loop.

Tracking ticket: CRED-2625. Surfaced in terraform-provider-datadog#3757.

🤖 Generated with [Claude Code](https://claude.com/claude-code)