### PR TITLE
Pin reusable workflow actions to full commit SHAs

### DIFF
--- a/.github/workflows/approved_status.yml
+++ b/.github/workflows/approved_status.yml
@@ -32,7 +32,7 @@ jobs:
           scope: DataDog/datadog-api-spec
           policy: datadog-api-client-typescript.approved_status.post-review-status
       - name: Post PR review status check
-        uses: DataDog/github-actions/post-review-status@v2
+        uses: DataDog/github-actions/post-review-status@65b4875f33ad773d7ba4b005a2cb5f35020295f3 # v2.3.0
         with:
           github-token: ${{ steps.get_token.outputs.token }}
           repo: datadog-api-spec

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@cdcdbb579706841c47f7063dda365e292e5cad7a # v2
         with:
           languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@cdcdbb579706841c47f7063dda365e292e5cad7a # v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@cdcdbb579706841c47f7063dda365e292e5cad7a # v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v4.4.0
         with:
           node-version: 16
           cache: 'yarn'
@@ -32,7 +32,7 @@ jobs:
       - name: Compress docs
         run: tar czf docs.tar.gz docs
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: documentation
           path: docs.tar.gz
@@ -45,7 +45,7 @@ jobs:
       - build
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: documentation
           path: docs
@@ -53,7 +53,7 @@ jobs:
       - name: Uncompress docs
         run: tar xzf docs/docs.tar.gz && rm docs/docs.tar.gz
 
-      - uses: peaceiris/actions-gh-pages@v3
+      - uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: DataDog/labeler@glob-all
+      - uses: DataDog/labeler@5170395583c7f7ec92989fd24faffc5b6154b866 # glob-all
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v4.4.0
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -28,12 +28,12 @@ jobs:
   examples:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: DataDog/datadog-api-client-typescript
           ref: ${{ inputs.target-branch || github.ref }}
       - name: Set up Node ${{ inputs.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v4.4.0
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'yarn'

--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -89,20 +89,20 @@ jobs:
           scope: DataDog/datadog-api-spec
           policy: datadog-api-client-typescript.reusable-integration-test.post-status
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: DataDog/datadog-api-client-typescript
           ref: ${{ inputs.target-branch || github.ref }}
       - name: Post pending status check
         if: github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/') && (inputs.enable-status-reporting || github.event_name != 'workflow_call')
-        uses: DataDog/github-actions/post-status-check@v2
+        uses: DataDog/github-actions/post-status-check@65b4875f33ad773d7ba4b005a2cb5f35020295f3 # v2.3.0
         with:
           github-token: ${{ steps.get_token.outputs.token }}
           repo: ${{ inputs.target-repo || 'datadog-api-spec' }}
           status: pending
           context: ${{ inputs.status-context || 'integration' }}
       - name: Set up Node 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v4.4.0
         with:
           node-version: 16
           cache: 'yarn'
@@ -122,7 +122,7 @@ jobs:
           SLEEP_AFTER_REQUEST: ${{ secrets.SLEEP_AFTER_REQUEST || vars.SLEEP_AFTER_REQUEST }}
       - name: Post failure status check
         if: failure() && github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/') && (inputs.enable-status-reporting || github.event_name != 'workflow_call')
-        uses: DataDog/github-actions/post-status-check@v2
+        uses: DataDog/github-actions/post-status-check@65b4875f33ad773d7ba4b005a2cb5f35020295f3 # v2.3.0
         with:
           github-token: ${{ steps.get_token.outputs.token }}
           repo: ${{ inputs.target-repo || 'datadog-api-spec' }}
@@ -130,7 +130,7 @@ jobs:
           context: ${{ inputs.status-context || 'integration' }}
       - name: Post success status check
         if: "!failure() && github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/') && (inputs.enable-status-reporting || github.event_name != 'workflow_call')"
-        uses: DataDog/github-actions/post-status-check@v2
+        uses: DataDog/github-actions/post-status-check@65b4875f33ad773d7ba4b005a2cb5f35020295f3 # v2.3.0
         with:
           github-token: ${{ steps.get_token.outputs.token }}
           repo: ${{ inputs.target-repo || 'datadog-api-spec' }}

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -32,20 +32,20 @@ jobs:
         with:
           scope: DataDog/datadog-api-client-typescript
           policy: self.github.pre-commit.pull-requests
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           repository: DataDog/datadog-api-client-typescript
           ref: ${{ inputs.target-branch || github.event.pull_request.head.sha || github.ref }}
           token: ${{ inputs.enable-commit-changes && steps.get_token.outputs.token || github.token }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.11'
       - name: Install pre-commit
         run: python -m pip install pre-commit
       - name: set PY
         run: echo "PY=$(python -c 'import hashlib, sys, platform;print(hashlib.sha256(platform.python_version().encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/reusable-typescript-test.yml
+++ b/.github/workflows/reusable-typescript-test.yml
@@ -37,12 +37,12 @@ jobs:
         platform: ${{ fromJSON(inputs.platforms) }}
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: DataDog/datadog-api-client-typescript
           ref: ${{ inputs.target-branch || github.ref }}
       - name: Set up Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: >-

--- a/.github/workflows/static-analysis.datadog.yml
+++ b/.github/workflows/static-analysis.datadog.yml
@@ -11,10 +11,10 @@ jobs:
     name: Datadog Static Analyzer
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Check code meets quality standards
       id: datadog-static-analysis
-      uses: DataDog/datadog-static-analyzer-github-action@v1
+      uses: DataDog/datadog-static-analyzer-github-action@4b0a60943e8263c9d574254bbb206a87a0f75531 # v1
       with:
         dd_api_key: ${{ secrets.DD_API_KEY }}
         dd_app_key: ${{ secrets.DD_APP_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
           scope: DataDog/datadog-api-spec
           policy: datadog-api-client-typescript.test.post-status
       - name: Post status check
-        uses: DataDog/github-actions/post-status-check@v2
+        uses: DataDog/github-actions/post-status-check@65b4875f33ad773d7ba4b005a2cb5f35020295f3 # v2.3.0
         with:
           github-token: ${{ steps.get_token.outputs.token }}
           repo: datadog-api-spec


### PR DESCRIPTION
### What does this PR do?
The datadog-api-spec repo enforces a policy requiring all GitHub Actions to be pinned to full commit SHAs — tag references like @v3 or @v4 are rejected at job setup time, causing all test jobs to fail. This updates all reusable workflow files to pin every action to its full commit SHA. Triggered by failures seen in https://github.com/DataDog/datadog-api-spec/actions/runs/26498375372.
### Additional Notes
(none)
### Review checklist
- [ ] This PR includes all newly recorded cassettes for any modified tests.
- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.