### PR TITLE
Pin reusable workflow actions to full commit SHAs (v2)

### DIFF
--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     if: (github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci/skip') && !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')) || github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: DataDog/datadog-api-client-typescript
           ref: ${{ inputs.target-branch || github.ref }}
@@ -33,7 +33,7 @@ jobs:
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
       - name: Set up Node ${{ inputs.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v4.4.0
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'yarn'

--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -31,20 +31,20 @@ jobs:
         with:
           scope: DataDog/datadog-api-client-typescript
           policy: self.github.pre-commit.pull-requests
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           repository: DataDog/datadog-api-client-typescript
           ref: ${{ inputs.target-branch || github.event.pull_request.head.sha || github.ref }}
           token: ${{ inputs.enable-commit-changes && steps.get_token.outputs.token || github.token }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.11'
       - name: Install pre-commit
         run: python -m pip install pre-commit
       - name: set PY
         run: echo "PY=$(python -c 'import hashlib, sys, platform;print(hashlib.sha256(platform.python_version().encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|split-package|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/reusable-typescript-test.yml
+++ b/.github/workflows/reusable-typescript-test.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     if: (github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci/skip') && !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')) || github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: DataDog/datadog-api-client-typescript
           ref: ${{ inputs.target-branch || github.ref }}
@@ -41,7 +41,7 @@ jobs:
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
       - name: Set up Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
           spec_pr=$(echo "${{ github.event.pull_request.head.ref }}" | sed 's/.*generated\/\([0-9]*\).*/\1/')
           echo "spec_pr=${spec_pr}" >> $GITHUB_OUTPUT
       - name: Post status check
-        uses: DataDog/github-actions/post-status-check@v2
+        uses: DataDog/github-actions/post-status-check@65b4875f33ad773d7ba4b005a2cb5f35020295f3 # v2.3.0
         with:
           github-token: ${{ steps.get_token.outputs.token }}
           repo: datadog-api-spec


### PR DESCRIPTION
### What does this PR do?
The datadog-api-spec repo enforces a policy requiring all GitHub Actions to be pinned to full commit SHAs — tag references like @v3 or @v4 are rejected at job setup time, causing all test jobs to fail. This updates all reusable workflow files to pin every action to its full commit SHA. Triggered by failures seen in https://github.com/DataDog/datadog-api-spec/actions/runs/26498375372.
### Additional Notes
(none)
### Review checklist
- [ ] This PR includes all newly recorded cassettes for any modified tests.
- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.