### PR TITLE
Bump CI Node.js versions from 16/18 to 20/22

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -12,7 +12,7 @@ on:
         description: 'JSON array of Node.js versions to test against'
         required: false
         type: string
-        default: '["16", "18"]'
+        default: '["20", "22"]'
       platforms:
         description: 'JSON array of platforms to run tests on'
         required: false
@@ -32,7 +32,7 @@ on:
         description: 'Node.js version to use'
         required: false
         type: string
-        default: '16'
+        default: '20'
 
     secrets:
       # Integration test secrets

--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           repository: DataDog/datadog-api-client-typescript
           ref: ${{ inputs.target-branch || github.ref }}
+      - name: Enable Corepack
+        run: corepack enable
       - name: Set up Node ${{ inputs.node-version }}
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v4.4.0
         with:

--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -17,7 +17,7 @@ on:
         description: 'Node.js version to use for examples'
         required: false
         type: string
-        default: '16'
+        default: '20'
     secrets:
       PIPELINE_GITHUB_APP_ID:
         required: false

--- a/.github/workflows/reusable-typescript-test.yml
+++ b/.github/workflows/reusable-typescript-test.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           repository: DataDog/datadog-api-client-typescript
           ref: ${{ inputs.target-branch || github.ref }}
+      - name: Enable Corepack
+        run: corepack enable
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v4.4.0
         with:

--- a/.github/workflows/reusable-typescript-test.yml
+++ b/.github/workflows/reusable-typescript-test.yml
@@ -12,7 +12,7 @@ on:
         description: 'JSON array of Node.js versions to test against'
         required: false
         type: string
-        default: '["16", "18"]'
+        default: '["20", "22"]'
       platforms:
         description: 'JSON array of platforms to run tests on'
         required: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       github.event_name == 'schedule'
     uses: ./.github/workflows/reusable-typescript-test.yml
     with:
-      node-versions: '["16", "18"]'
+      node-versions: '["20", "22"]'
       platforms: '["ubuntu-latest"]'
       test-script: './run-tests.sh'
 
@@ -53,7 +53,7 @@ jobs:
     uses: ./.github/workflows/reusable-examples.yml
     with:
       examples-script: './check-examples.sh'
-      node-version: '16'
+      node-version: '20'
 
   report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does this PR do?

Node 16 reached end-of-life in September 2023 and Node 18 reached EOL in April 2025. This PR updates the default Node.js versions used across the reusable CI workflows from `["16", "18"]` to `["20", "22"]`, and the single-version defaults from `16` to `20`.

### Additional Notes

No functional changes — only the Node.js versions used in the CI matrix are updated.

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.