### PR TITLE
AAWF-504 fix: avoid accessing process.release in VS Code extension host

### DIFF
--- a/packages/datadog-api-client-common/util.ts
+++ b/packages/datadog-api-client-common/util.ts
@@ -19,8 +19,8 @@ export const isBrowser: boolean =
 
 export const isNode: boolean =
   typeof process !== "undefined" &&
-  process.release &&
-  process.release.name === "node";
+  process.versions != null &&
+  process.versions.node != null;
 
 export class DDate extends Date {
   originalDate: string | undefined;


### PR DESCRIPTION
## What does this PR do?

Fixes the `extensionRuntime` proposed API error thrown when using the client inside a VS Code extension.

## Motivation

VS Code 1.96 gates `process.release` behind the `extensionRuntime` proposed API. Since `isNode` is a module-level constant, it is evaluated at import time — meaning the very first API call (e.g. `.submitLog()`) throws:

```
CANNOT use API proposal: extensionRuntime.
Its package.json#enabledApiProposals-property declares: [] but NOT extensionRuntime.
```

## Solution

Replace `process.release.name === "node"` with `process.versions.node != null`.

`process.release` is documented as ["metadata related to the current release"](https://nodejs.org/api/process.html#processrelease) — it was never designed as an environment detection mechanism, and VS Code 1.96 proved this by gating it behind a proposed API. `process.versions.node`, on the other hand, is documented as an always-present property in Node.js environments and is not restricted by VS Code's sandbox.

| Property | Node.js | Browser | VS Code ext host |
|---|---|---|---|
| `process.release` | ✅ available | ❌ | 🔒 gated (proposed API) |
| `process.versions.node` | ✅ version string | ❌ | ✅ available |

## Testing

All existing tests pass (`npx jest tests/api/`).

Closes #2468