### PR TITLE
Use generated BDD test artifacts

### DIFF
--- a/features/step_definitions/request_steps.ts
+++ b/features/step_definitions/request_steps.ts
@@ -4,7 +4,11 @@ import chaiQuantifiers from "chai-quantifiers";
 use(chaiQuantifiers);
 import { World } from "../support/world";
 
-import { getProperty, pathLookup, getTypeForValue } from "../support/templating";
+import {
+  getProperty,
+  pathLookup,
+  getTypeForValue,
+} from "../support/templating";
 import { Store } from "../support/store";
 import { buildUndoFor, UndoActions } from "../support/undo";
 import * as datadogApiClient from "../../index";
@@ -14,7 +18,13 @@ import path from "path";
 import { compressSync } from "zstd.ts";
 import log from "loglevel";
 import { ScenariosModelMappings } from "../support/scenarios_model_mapping";
-const logger = log.getLogger("testing")
+import {
+  applyTestRunnerPlan,
+  markMainRequestComplete,
+  testRunnerEnabled,
+  testServerFetch,
+} from "../support/test_runner";
+const logger = log.getLogger("testing");
 logger.setLevel(process.env.DEBUG ? logger.levels.DEBUG : logger.levels.INFO);
 
 Given('a valid "apiKeyAuth" key in the system', function (this: World) {
@@ -38,10 +48,12 @@ Given(
 );
 
 Given(/body with value (.*)/, function (this: World, body: string) {
+  if (testRunnerEnabled()) return;
   this.opts["body"] = JSON.parse(body.templated(this.fixtures));
 });
 
 Given(/body from file "(.*)"/, function (this: World, filename: string) {
+  if (testRunnerEnabled()) return;
   const content = fs
     .readFileSync(path.join(__dirname, `../${this.apiVersion}`, filename))
     .toString();
@@ -51,6 +63,7 @@ Given(/body from file "(.*)"/, function (this: World, filename: string) {
 Given(
   "request contains {string} parameter from {string}",
   function (this: World, parameterName: string, fixturePath: string) {
+    if (testRunnerEnabled()) return;
     const value = pathLookup(this.fixtures, fixturePath);
     this.opts[parameterName.toAttributeName()] = value;
     // Store in pathParameters for undo operations with naming variants
@@ -62,6 +75,7 @@ Given(
 Given(
   /request contains "([^"]+)" parameter with value (.*)/,
   function (this: World, parameterName: string, value: string) {
+    if (testRunnerEnabled()) return;
     const parsedValue = JSON.parse(value.templated(this.fixtures));
     const attrName = parameterName.toAttributeName().toOperationName();
     this.opts[attrName] = parsedValue;
@@ -72,19 +86,23 @@ Given(
 );
 
 Given("new {string} request", function (this: World, operationId: string) {
+  if (testRunnerEnabled()) return;
   this.operationId = operationId;
   this.opts = {};
   this.pathParameters = {}; // Clear path parameters for new request
 });
 
 When("the request is sent", async function (this: World) {
+  applyTestRunnerPlan(this, false);
   // build request from scenario
   const api = (datadogApiClient as any)[this.apiVersion];
   const configurationOpts = {
     authMethods: this.authMethods,
     httpConfig: { compress: false },
-    zstdCompressorCallback: (body: string) => compressSync({input: Buffer.from(body, "utf8")}),
+    zstdCompressorCallback: (body: string) =>
+      compressSync({ input: Buffer.from(body, "utf8") }),
     enableRetry: true,
+    fetch: testServerFetch(this.testServerSession),
   };
   if (process.env.DD_TEST_SITE) {
     const serverConf = datadogApiClient.client.servers[2].getConfiguration();
@@ -101,10 +119,21 @@ When("the request is sent", async function (this: World) {
     } as typeof serverConf);
     (configurationOpts as any)["serverIndex"] = 1;
   }
-  const configuration = datadogApiClient.client.createConfiguration(configurationOpts);
+  if (process.env.DD_TEST_SERVER_URL) {
+    (configurationOpts as any)["baseServer"] =
+      new datadogApiClient.client.BaseServerConfiguration(
+        process.env.DD_TEST_SERVER_URL,
+        {}
+      );
+  }
+  const configuration =
+    datadogApiClient.client.createConfiguration(configurationOpts);
   for (const operationId in this.unstableOperations) {
-    if (`${this.apiVersion}.${operationId}` in configuration.unstableOperations) {
-      configuration.unstableOperations[`${this.apiVersion}.${operationId}`] = this.unstableOperations[operationId];
+    if (
+      `${this.apiVersion}.${operationId}` in configuration.unstableOperations
+    ) {
+      configuration.unstableOperations[`${this.apiVersion}.${operationId}`] =
+        this.unstableOperations[operationId];
     } else {
       // FIXME throw new Error(`Operation ${operationId} is not unstable`);
       logger.warn(`Operation ${operationId} is not unstable`);
@@ -120,14 +149,25 @@ When("the request is sent", async function (this: World) {
   }
 
   // Deserialize obejcts into correct model types
-  const objectSerializer = getProperty(datadogApiClient, this.apiVersion).ObjectSerializer;
-  Object.keys(this.opts).forEach(key => {
-    const type = ScenariosModelMappings[`${this.apiVersion}.${this.operationId}`][key].type
-    const format = ScenariosModelMappings[`${this.apiVersion}.${this.operationId}`][key].format
+  const objectSerializer = getProperty(
+    datadogApiClient,
+    this.apiVersion
+  ).ObjectSerializer;
+  Object.keys(this.opts).forEach((key) => {
+    const type =
+      ScenariosModelMappings[`${this.apiVersion}.${this.operationId}`][key]
+        .type;
+    const format =
+      ScenariosModelMappings[`${this.apiVersion}.${this.operationId}`][key]
+        .format;
 
     if (type === "HttpFile" && format === "binary") {
       this.opts[key] = {
-        data: Buffer.from(fs.readFileSync(path.join(__dirname, `../${this.apiVersion}`, this.opts[key]))),
+        data: Buffer.from(
+          fs.readFileSync(
+            path.join(__dirname, `../${this.apiVersion}`, this.opts[key])
+          )
+        ),
         name: this.opts[key],
       };
     } else {
@@ -135,7 +175,7 @@ When("the request is sent", async function (this: World) {
         this.opts[key],
         type,
         format
-        )
+      );
     }
   });
 
@@ -161,7 +201,8 @@ When("the request is sent", async function (this: World) {
           this.operationId,
           this.response,
           this.opts,
-          this.pathParameters
+          this.pathParameters,
+          this.testServerSession
         )
       );
     }
@@ -175,19 +216,27 @@ When("the request is sent", async function (this: World) {
     if (this.requestContext === undefined) {
       throw error;
     }
-    if (this.requestContext !== undefined && this.requestContext.headers["content-type"] == "application/problem+json" && this.requestContext.httpStatusCode == 500) {
+    if (
+      this.requestContext !== undefined &&
+      this.requestContext.headers["content-type"] ==
+        "application/problem+json" &&
+      this.requestContext.httpStatusCode == 500
+    ) {
       logger.debug(this.requestContext.body.text);
       throw error;
     }
   }
+  await markMainRequestComplete(this);
 });
 
 When("the request with pagination is sent", async function (this: World) {
+  applyTestRunnerPlan(this, true);
   const api = (datadogApiClient as any)[this.apiVersion];
   const configurationOpts = {
     authMethods: this.authMethods,
     httpConfig: { compress: false },
     enableRetry: true,
+    fetch: testServerFetch(this.testServerSession),
   };
   if (process.env.DD_TEST_SITE) {
     const serverConf = datadogApiClient.client.servers[2].getConfiguration();
@@ -204,10 +253,21 @@ When("the request with pagination is sent", async function (this: World) {
     } as typeof serverConf);
     (configurationOpts as any)["serverIndex"] = 1;
   }
-  const configuration = datadogApiClient.client.createConfiguration(configurationOpts);
+  if (process.env.DD_TEST_SERVER_URL) {
+    (configurationOpts as any)["baseServer"] =
+      new datadogApiClient.client.BaseServerConfiguration(
+        process.env.DD_TEST_SERVER_URL,
+        {}
+      );
+  }
+  const configuration =
+    datadogApiClient.client.createConfiguration(configurationOpts);
   for (const operationId in this.unstableOperations) {
-    if (`${this.apiVersion}.${operationId}` in configuration.unstableOperations) {
-      configuration.unstableOperations[`${this.apiVersion}.${operationId}`] = this.unstableOperations[operationId];
+    if (
+      `${this.apiVersion}.${operationId}` in configuration.unstableOperations
+    ) {
+      configuration.unstableOperations[`${this.apiVersion}.${operationId}`] =
+        this.unstableOperations[operationId];
     } else {
       // FIXME throw new Error(`Operation ${operationId} is not unstable`);
       logger.warn(`Operation ${operationId} is not unstable`);
@@ -216,13 +276,18 @@ When("the request with pagination is sent", async function (this: World) {
   const apiInstance = new api[`${this.apiName}Api`](configuration);
 
   // Deserialize obejcts into correct model types
-  const objectSerializer = getProperty(datadogApiClient, this.apiVersion).ObjectSerializer;
-  Object.keys(this.opts).forEach(key => {
+  const objectSerializer = getProperty(
+    datadogApiClient,
+    this.apiVersion
+  ).ObjectSerializer;
+  Object.keys(this.opts).forEach((key) => {
     this.opts[key] = objectSerializer.deserialize(
       this.opts[key],
-      ScenariosModelMappings[`${this.apiVersion}.${this.operationId}`][key].type,
-      ScenariosModelMappings[`${this.apiVersion}.${this.operationId}`][key].format
-      )
+      ScenariosModelMappings[`${this.apiVersion}.${this.operationId}`][key]
+        .type,
+      ScenariosModelMappings[`${this.apiVersion}.${this.operationId}`][key]
+        .format
+    );
   });
 
   // store request context from response processor
@@ -232,11 +297,15 @@ When("the request with pagination is sent", async function (this: World) {
   try {
     let response: any = [];
     if (Object.keys(this.opts).length) {
-      for await (const item of apiInstance[this.operationId.toOperationName() + "WithPagination"](this.opts)) {
+      for await (const item of apiInstance[
+        this.operationId.toOperationName() + "WithPagination"
+      ](this.opts)) {
         response.push(item);
       }
     } else {
-      for await (const item of apiInstance[this.operationId.toOperationName() + "WithPagination"]()) {
+      for await (const item of apiInstance[
+        this.operationId.toOperationName() + "WithPagination"
+      ]()) {
         response.push(item);
       }
     }
@@ -251,11 +320,17 @@ When("the request with pagination is sent", async function (this: World) {
     if (this.requestContext === undefined) {
       throw error;
     }
-    if (this.requestContext !== undefined && this.requestContext.headers["content-type"] == "application/problem+json" && this.requestContext.httpStatusCode == 500) {
+    if (
+      this.requestContext !== undefined &&
+      this.requestContext.headers["content-type"] ==
+        "application/problem+json" &&
+      this.requestContext.httpStatusCode == 500
+    ) {
       logger.debug(this.requestContext.body.text);
       throw error;
     }
   }
+  await markMainRequestComplete(this);
 });
 
 Then(
@@ -277,13 +352,20 @@ Then(
 Then(
   /the response "([^"]+)" is equal to (.*)/,
   function (this: World, responsePath: string, value: string) {
-    const pathResult = pathLookup(this.response, responsePath)
-    const _type = getTypeForValue(pathResult)
-    let templatedFixtureValue = JSON.parse(value.templated(this.fixtures))
+    const pathResult = pathLookup(this.response, responsePath);
+    const _type = getTypeForValue(pathResult);
+    let templatedFixtureValue = JSON.parse(value.templated(this.fixtures));
 
     if (_type) {
-      const objectSerializer = getProperty(datadogApiClient, this.apiVersion).ObjectSerializer;
-      templatedFixtureValue = objectSerializer.deserialize(templatedFixtureValue, _type, "")
+      const objectSerializer = getProperty(
+        datadogApiClient,
+        this.apiVersion
+      ).ObjectSerializer;
+      templatedFixtureValue = objectSerializer.deserialize(
+        templatedFixtureValue,
+        _type,
+        ""
+      );
     }
 
     expect(pathResult).to.deep.equal(templatedFixtureValue);
@@ -300,14 +382,17 @@ Then(
 Then(
   "the response {string} has field {string}",
   function (this: World, responsePath: string, field: string) {
-    expect(pathLookup(this.response, responsePath)).to.have.property(field.toAttributeName());
+    expect(pathLookup(this.response, responsePath)).to.have.property(
+      field.toAttributeName()
+    );
   }
 );
 
 Then(
   "the response {string} does not have field {string}",
   function (this: World, responsePath: string, field: string) {
-    expect(pathLookup(this.response, responsePath)[field.toAttributeName()]).to.be.undefined;
+    expect(pathLookup(this.response, responsePath)[field.toAttributeName()]).to
+      .be.undefined;
   }
 );
 
@@ -346,16 +431,22 @@ Then(
 Then(
   /the response "([^"]+)" array contains value (.*)/,
   function (this: World, responsePath: string, value: string) {
-    expect(pathLookup(this.response, responsePath)).to.contain(JSON.parse(value.templated(this.fixtures)));
+    expect(pathLookup(this.response, responsePath)).to.contain(
+      JSON.parse(value.templated(this.fixtures))
+    );
   }
 );
 
-AfterAll( function (this: World) {
+AfterAll(function (this: World) {
   let dd_service = process.env.DD_SERVICE;
   let ci_pipeline_id = process.env.GITHUB_RUN_ID;
   if (dd_service !== undefined && ci_pipeline_id !== undefined) {
-    console.log("\nTest reports:\n")
-    console.log("* View test APM traces and detailed time reports on Datadog (can take a few minutes to become available):")
-    console.log(`* https://app.datadoghq.com/ci/test-runs?query=%40test.service%3A${dd_service}%20%40ci.pipeline.id%3A${ci_pipeline_id}&index=citest\n`)
+    console.log("\nTest reports:\n");
+    console.log(
+      "* View test APM traces and detailed time reports on Datadog (can take a few minutes to become available):"
+    );
+    console.log(
+      `* https://app.datadoghq.com/ci/test-runs?query=%40test.service%3A${dd_service}%20%40ci.pipeline.id%3A${ci_pipeline_id}&index=citest\n`
+    );
   }
 });

--- a/features/support/given.ts
+++ b/features/support/given.ts
@@ -1,5 +1,5 @@
 import { Given } from "@cucumber/cucumber";
-import { compressSync } from 'zstd.ts'
+import { compressSync } from "zstd.ts";
 
 import fs from "fs";
 import path from "path";
@@ -9,6 +9,7 @@ import { getProperty, pathLookup } from "./templating";
 import { UndoActions, buildUndoFor } from "./undo";
 import * as datadogApiClient from "../../index";
 import { ScenariosModelMappings } from "./scenarios_model_mapping";
+import { testServerFetch } from "./test_runner";
 
 interface IOperationParameter {
   name: string;
@@ -46,8 +47,10 @@ for (const apiVersion of Versions) {
           appKeyAuth: process.env.DD_TEST_CLIENT_APP_KEY,
         },
         httpConfig: { compress: false },
-        zstdCompressorCallback: (body: string) => compressSync({ input: Buffer.from(body, "utf8") }),
+        zstdCompressorCallback: (body: string) =>
+          compressSync({ input: Buffer.from(body, "utf8") }),
         enableRetry: true,
+        fetch: testServerFetch(this.testServerSession),
       };
 
       if (process.env.DD_TEST_SITE) {
@@ -59,16 +62,28 @@ for (const apiVersion of Versions) {
         (configurationOpts as any)["baseServer"] = server;
       }
       if (process.env.DD_TEST_SITE_URL) {
-        const serverConf = datadogApiClient.client.servers[1].getConfiguration();
+        const serverConf =
+          datadogApiClient.client.servers[1].getConfiguration();
         datadogApiClient.client.servers[1].setVariables({
           name: process.env.DD_TEST_SITE_URL,
           protocol: "http",
         } as typeof serverConf);
         (configurationOpts as any)["serverIndex"] = 1;
       }
-      const configuration = datadogApiClient.client.createConfiguration(configurationOpts);
-      if (`${apiVersion}.${operationName}` in configuration.unstableOperations) {
-        configuration.unstableOperations[`${apiVersion}.${operationName}`] = true;
+      if (process.env.DD_TEST_SERVER_URL) {
+        (configurationOpts as any)["baseServer"] =
+          new datadogApiClient.client.BaseServerConfiguration(
+            process.env.DD_TEST_SERVER_URL,
+            {}
+          );
+      }
+      const configuration =
+        datadogApiClient.client.createConfiguration(configurationOpts);
+      if (
+        `${apiVersion}.${operationName}` in configuration.unstableOperations
+      ) {
+        configuration.unstableOperations[`${apiVersion}.${operationName}`] =
+          true;
       }
       const apiInstance = new (api as any)[`${apiName}Api`](configuration);
 
@@ -89,9 +104,7 @@ for (const apiVersion of Versions) {
       if (operation.parameters !== undefined) {
         for (const p of operation.parameters) {
           if (p.value !== undefined) {
-            const value = JSON.parse(
-              p.value?.templated(this.fixtures),
-            );
+            const value = JSON.parse(p.value?.templated(this.fixtures));
             opts[p.name.toAttributeName()] = value;
 
             // Store in pathParameters for undo operations with naming variants
@@ -99,10 +112,7 @@ for (const apiVersion of Versions) {
             this.pathParameters[p.name.toAttributeName()] = value;
           }
           if (p.source !== undefined) {
-            const value = pathLookup(
-              this.fixtures,
-              p.source
-            );
+            const value = pathLookup(this.fixtures, p.source);
             opts[p.name.toAttributeName()] = value;
 
             // Store in pathParameters for undo operations with naming variants
@@ -120,22 +130,29 @@ for (const apiVersion of Versions) {
       }
 
       // Deserialize obejcts into correct model types
-      const objectSerializer = getProperty(datadogApiClient, apiVersion).ObjectSerializer;
-      Object.keys(opts).forEach(key => {
-        const type = ScenariosModelMappings[`${apiVersion}.${operation.operationId}`][key].type
-        const format = ScenariosModelMappings[`${apiVersion}.${operation.operationId}`][key].format
+      const objectSerializer = getProperty(
+        datadogApiClient,
+        apiVersion
+      ).ObjectSerializer;
+      Object.keys(opts).forEach((key) => {
+        const type =
+          ScenariosModelMappings[`${apiVersion}.${operation.operationId}`][key]
+            .type;
+        const format =
+          ScenariosModelMappings[`${apiVersion}.${operation.operationId}`][key]
+            .format;
 
         if (type === "HttpFile" && format === "binary") {
           opts[key] = {
-            data: Buffer.from(fs.readFileSync(path.join(__dirname, `../${apiVersion}`, opts[key]))),
+            data: Buffer.from(
+              fs.readFileSync(
+                path.join(__dirname, `../${apiVersion}`, opts[key])
+              )
+            ),
             name: opts[key],
           };
         } else {
-          opts[key] = objectSerializer.deserialize(
-            opts[key],
-            type,
-            format
-          )
+          opts[key] = objectSerializer.deserialize(opts[key], type, format);
         }
       });
 
@@ -150,7 +167,15 @@ for (const apiVersion of Versions) {
       // register undo method
       if (undoAction.undo.type == "unsafe") {
         this.undo.push(
-          buildUndoFor(apiVersion, undoAction, operationName, result, opts, this.pathParameters)
+          buildUndoFor(
+            apiVersion,
+            undoAction,
+            operationName,
+            result,
+            opts,
+            this.pathParameters,
+            this.testServerSession
+          )
         );
       }
 

--- a/features/support/test_runner.ts
+++ b/features/support/test_runner.ts
@@ -1,0 +1,197 @@
+import fs from "fs";
+import path from "path";
+import { fetch as crossFetch } from "cross-fetch";
+
+import { pathLookup } from "./templating";
+import { World } from "./world";
+
+const CONTROL_ROOT = "/__openapi_transformer__";
+const TEMPLATE_KEY = "$openapi_transformer_template";
+const fetchImpl =
+  typeof globalThis.fetch === "function" ? globalThis.fetch : crossFetch;
+
+interface TestRunnerManifestItem {
+  version: string;
+  feature: string;
+  scenario: string;
+  file: string;
+}
+
+interface TestRunnerPlan {
+  api: string;
+  operation_id: string;
+  request: {
+    body?: { value: any };
+    parameters: Array<{
+      name: string;
+      source: {
+        type: "fixture" | "literal";
+        path?: string;
+        value?: any;
+      };
+    }>;
+    pagination: boolean;
+  };
+}
+
+export function testRunnerEnabled(): boolean {
+  return process.env.DD_TEST_RUNNER_DATA !== undefined;
+}
+
+export function testServerEnabled(): boolean {
+  return process.env.DD_TEST_SERVER_URL !== undefined;
+}
+
+async function controlRequest(endpoint: string, body?: any): Promise<any> {
+  const response = await fetchImpl(
+    `${process.env.DD_TEST_SERVER_URL}${CONTROL_ROOT}${endpoint}`,
+    {
+      method: "POST",
+      headers: {
+        connection: "close",
+        "content-type": "application/json",
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    }
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Test server POST ${endpoint} failed (${
+        response.status
+      }): ${await response.text()}`
+    );
+  }
+  return response.json();
+}
+
+export async function startTestServerSession(
+  world: World,
+  feature: string,
+  scenario: string
+): Promise<Date> {
+  world.testFeature = feature;
+  world.testScenario = scenario;
+  const session = await controlRequest("/sessions", {
+    version: world.apiVersion,
+    feature,
+    scenario,
+  });
+  world.testServerSession = session.session;
+  return new Date(session.frozen_at);
+}
+
+export async function stopTestServerSession(world: World): Promise<void> {
+  if (world.testServerSession === undefined) {
+    return;
+  }
+  const result = await controlRequest(
+    `/sessions/${world.testServerSession}/stop`
+  );
+  world.testServerSession = undefined;
+  if (result.complete === false) {
+    throw new Error(
+      `Test server session consumed ${result.interactions} of ${result.total_interactions} interactions`
+    );
+  }
+}
+
+export async function markMainRequestComplete(world: World): Promise<void> {
+  if (world.testServerSession === undefined) {
+    return;
+  }
+  await controlRequest(`/sessions/${world.testServerSession}/main-complete`);
+}
+
+export function testServerFetch(session?: string): any {
+  if (!testServerEnabled()) {
+    return undefined;
+  }
+  if (session === undefined) {
+    throw new Error("Generated test-server session has not been started");
+  }
+  return (url: string, options: any = {}) => {
+    options.headers = {
+      ...(options.headers || {}),
+      connection: "close",
+      "x-openapi-test-session": session,
+    };
+    return fetchImpl(url, options);
+  };
+}
+
+function materialize(value: any, fixtures: { [key: string]: any }): any {
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 1 &&
+    TEMPLATE_KEY in value
+  ) {
+    return JSON.parse(value[TEMPLATE_KEY].templated(fixtures));
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => materialize(item, fixtures));
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        materialize(item, fixtures),
+      ])
+    );
+  }
+  if (typeof value === "string") {
+    return value.templated(fixtures);
+  }
+  return value;
+}
+
+function loadPlan(world: World): TestRunnerPlan {
+  const root = path.resolve(process.env.DD_TEST_RUNNER_DATA as string);
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(root, "manifest.json")).toString()
+  );
+  const item = manifest.scenarios.find(
+    (candidate: TestRunnerManifestItem) =>
+      candidate.version === world.apiVersion &&
+      candidate.feature === world.testFeature &&
+      candidate.scenario === world.testScenario
+  );
+  if (item === undefined) {
+    throw new Error(
+      `Generated request plan not found for ${world.apiVersion}/${world.testFeature}/${world.testScenario}`
+    );
+  }
+  return JSON.parse(fs.readFileSync(path.join(root, item.file)).toString());
+}
+
+export function applyTestRunnerPlan(world: World, pagination: boolean): void {
+  if (!testRunnerEnabled()) {
+    return;
+  }
+  const plan = loadPlan(world);
+  if (plan.request.pagination !== pagination) {
+    throw new Error(
+      `Generated request plan pagination mismatch for ${world.testFeature}/${world.testScenario}`
+    );
+  }
+
+  world.apiName = plan.api.replace("-", "");
+  world.operationId = plan.operation_id;
+  world.opts = {};
+  world.pathParameters = {};
+
+  if (plan.request.body != null) {
+    world.opts.body = materialize(plan.request.body.value, world.fixtures);
+  }
+  for (const parameter of plan.request.parameters) {
+    const value =
+      parameter.source.type === "fixture"
+        ? pathLookup(world.fixtures, parameter.source.path as string)
+        : materialize(parameter.source.value, world.fixtures);
+    const attribute = parameter.name.toAttributeName().toOperationName();
+    world.opts[attribute] = value;
+    world.pathParameters[parameter.name] = value;
+    world.pathParameters[attribute] = value;
+  }
+}

--- a/features/support/undo.ts
+++ b/features/support/undo.ts
@@ -5,8 +5,9 @@ import log from "loglevel";
 import { getProperty, pathLookup } from "./templating";
 import { ScenariosModelMappings } from "./scenarios_model_mapping";
 import * as datadogApiClient from "../../index";
+import { testServerFetch } from "./test_runner";
 
-const logger = log.getLogger("testing")
+const logger = log.getLogger("testing");
 logger.setLevel(process.env.DEBUG ? logger.levels.DEBUG : logger.levels.INFO);
 
 interface iOperationParameter {
@@ -46,7 +47,8 @@ function buildUndoFor(
   operationOrig: string,
   response: any,
   request: any,
-  pathParameters: { [key: string]: any } = {}
+  pathParameters: { [key: string]: any } = {},
+  testServerSession?: string
 ): { (): void } {
   return async function () {
     let apiName = operationUndo.tag.replace(/[\s-]/g, "");
@@ -63,6 +65,7 @@ function buildUndoFor(
       },
       httpConfig: { compress: false },
       enableRetry: true,
+      fetch: testServerFetch(testServerSession),
     };
     if (process.env.DD_TEST_SITE) {
       const server = datadogApiClient.client.servers[2];
@@ -80,7 +83,15 @@ function buildUndoFor(
       } as typeof serverConf);
       (configurationOpts as any)["serverIndex"] = 1;
     }
-    const configuration = datadogApiClient.client.createConfiguration(configurationOpts);
+    if (process.env.DD_TEST_SERVER_URL) {
+      (configurationOpts as any)["baseServer"] =
+        new datadogApiClient.client.BaseServerConfiguration(
+          process.env.DD_TEST_SERVER_URL,
+          {}
+        );
+    }
+    const configuration =
+      datadogApiClient.client.createConfiguration(configurationOpts);
     if (`${apiVersion}.${operationName}` in configuration.unstableOperations) {
       configuration.unstableOperations[`${apiVersion}.${operationName}`] = true;
     }
@@ -122,13 +133,20 @@ function buildUndoFor(
       }
     }
 
-    const objectSerializer = getProperty(datadogApiClient, apiVersion).ObjectSerializer;
-    Object.keys(opts).forEach(key => {
+    const objectSerializer = getProperty(
+      datadogApiClient,
+      apiVersion
+    ).ObjectSerializer;
+    Object.keys(opts).forEach((key) => {
       opts[key] = objectSerializer.deserialize(
         opts[key],
-        ScenariosModelMappings[`${apiVersion}.${operationUndo.undo.operationId}`][key].type,
-        ScenariosModelMappings[`${apiVersion}.${operationUndo.undo.operationId}`][key].format
-      )
+        ScenariosModelMappings[
+          `${apiVersion}.${operationUndo.undo.operationId}`
+        ][key].type,
+        ScenariosModelMappings[
+          `${apiVersion}.${operationUndo.undo.operationId}`
+        ][key].format
+      );
     });
 
     try {

--- a/features/support/vcr.ts
+++ b/features/support/vcr.ts
@@ -10,6 +10,11 @@ import { World } from "./world";
 import { ITestCaseHookParameter } from "@cucumber/cucumber/lib/support_code_library_builder/types";
 import { MODES } from "@pollyjs/utils";
 import { createHash } from "crypto";
+import {
+  startTestServerSession,
+  stopTestServerSession,
+  testServerEnabled,
+} from "./test_runner";
 
 Polly.register(NodeHttpAdapter);
 Polly.register(FSPersister);
@@ -39,68 +44,89 @@ function matchHeaders(input: Headers, req: Request): Headers {
 }
 
 function generateUuid(data: any): any {
-    const timestring = data.toString();
-    return timestring.slice(0,8) + "-0000-0000-0000-"+timestring.slice(0,10)+"00";
+  const timestring = data.toString();
+  return (
+    timestring.slice(0, 8) + "-0000-0000-0000-" + timestring.slice(0, 10) + "00"
+  );
 }
 
-Before(function (
+Before(async function (
   this: World,
   { gherkinDocument, pickle }: ITestCaseHookParameter
 ) {
-  const recordingsDir = path.resolve(
-    __dirname,
-    `../../cassettes/${this.apiVersion}`
-  );
-  const recordingName = `${gherkinDocument.feature?.name as string}/${pickle.name}`;
-  this.polly = new Polly(recordingName, {
-    adapters: ["node-http"],
-    flushRequestsOnStop: true,
-    persister: "fs",
-    matchRequestsBy: {
-      headers: matchHeaders,
-    },
-    mode: RecordMode[process.env.RECORD || "false"],
-    recordIfMissing: process.env.RERECORD_FAILED_TESTS === "true", // make sure that we match body exactly
-    recordFailedRequests: true, // make sure we can replay responses with 4xx codes
-    logLevel: !!process.env.DEBUG ? "debug" : "warn",
-    persisterOptions: {
-      fs: {
-        recordingsDir: recordingsDir,
-      },
-    },
-  });
-  const { server } = this.polly;
-
-  // register used cassettes
-  cassettes.push(path.join(recordingsDir, this.polly?.recordingId));
-
   let date: Date;
-  const frozen = path.join(
-    recordingsDir,
-    this.polly?.recordingId,
-    "frozen.json"
-  );
-  const frozenExists = fs.existsSync(frozen);
-  if (frozenExists && this.polly?.mode == MODES.REPLAY) {
-    date = new Date(JSON.parse(fs.readFileSync(frozen).toString()));
+  let server: any;
+  if (testServerEnabled()) {
+    date = await startTestServerSession(
+      this,
+      gherkinDocument.feature?.name as string,
+      pickle.name
+    );
   } else {
-    date = new Date();
-    if (
-      this.polly?.mode == MODES.RECORD ||
-      this.polly?.config?.recordIfMissing
-    ) {
-      fs.mkdirSync(path.dirname(frozen), { recursive: true });
-      fs.writeFileSync(frozen, JSON.stringify(date) + "\n");
-    } else if (this.polly?.mode == MODES.REPLAY) {
-      throw new Error(`Time file '${frozen}' not found: create one setting \`RECORD=true\` or ignore it using \`RECORD=none\``);
+    const recordingsDir = path.resolve(
+      __dirname,
+      `../../cassettes/${this.apiVersion}`
+    );
+    const recordingName = `${gherkinDocument.feature?.name as string}/${
+      pickle.name
+    }`;
+    this.polly = new Polly(recordingName, {
+      adapters: ["node-http"],
+      flushRequestsOnStop: true,
+      persister: "fs",
+      matchRequestsBy: {
+        headers: matchHeaders,
+      },
+      mode: RecordMode[process.env.RECORD || "false"],
+      recordIfMissing: process.env.RERECORD_FAILED_TESTS === "true", // make sure that we match body exactly
+      recordFailedRequests: true, // make sure we can replay responses with 4xx codes
+      logLevel: !!process.env.DEBUG ? "debug" : "warn",
+      persisterOptions: {
+        fs: {
+          recordingsDir: recordingsDir,
+        },
+      },
+    });
+    ({ server } = this.polly);
+
+    // register used cassettes
+    cassettes.push(path.join(recordingsDir, this.polly?.recordingId));
+
+    const frozen = path.join(
+      recordingsDir,
+      this.polly?.recordingId,
+      "frozen.json"
+    );
+    const frozenExists = fs.existsSync(frozen);
+    if (frozenExists && this.polly?.mode == MODES.REPLAY) {
+      date = new Date(JSON.parse(fs.readFileSync(frozen).toString()));
+    } else {
+      date = new Date();
+      if (
+        this.polly?.mode == MODES.RECORD ||
+        this.polly?.config?.recordIfMissing
+      ) {
+        fs.mkdirSync(path.dirname(frozen), { recursive: true });
+        fs.writeFileSync(frozen, JSON.stringify(date) + "\n");
+      } else if (this.polly?.mode == MODES.REPLAY) {
+        throw new Error(
+          `Time file '${frozen}' not found: create one setting \`RECORD=true\` or ignore it using \`RECORD=none\``
+        );
+      }
     }
-  }
 
-  const cassette = path.join(recordingsDir, this.polly?.recordingId, "recording.har")
-  const cassetteExists = fs.existsSync(cassette)
+    const cassette = path.join(
+      recordingsDir,
+      this.polly?.recordingId,
+      "recording.har"
+    );
+    const cassetteExists = fs.existsSync(cassette);
 
-  if (!cassetteExists && this.polly?.mode == MODES.REPLAY) {
-    throw new Error(`Cassette '${cassette}' not found: create one setting \`RECORD=true\` or ignore it using \`RECORD=none\``);
+    if (!cassetteExists && this.polly?.mode == MODES.REPLAY) {
+      throw new Error(
+        `Cassette '${cassette}' not found: create one setting \`RECORD=true\` or ignore it using \`RECORD=none\``
+      );
+    }
   }
 
   const now = date.getTime() / 1000;
@@ -108,43 +134,46 @@ Before(function (
   const prefix =
     this.polly?.mode == MODES.PASSTHROUGH ? "Test-Typescript" : "Test";
   const unique = `${prefix}-${name}-${Math.floor(now)}`;
-  const uniqueHash = createHash("sha256").update(unique).digest("hex").substring(0, 16);
+  const uniqueHash = createHash("sha256")
+    .update(unique)
+    .digest("hex")
+    .substring(0, 16);
   this.fixtures["unique"] = unique;
   this.fixtures["unique_lower"] = unique.toLowerCase();
   this.fixtures["unique_upper"] = unique.toUpperCase();
   this.fixtures["unique_alnum"] = unique.replace(/[^A-Za-z0-9]+/g, "");
-  this.fixtures["unique_lower_alnum"] = this.fixtures[
-    "unique_alnum"
-  ].toLowerCase();
-  this.fixtures["unique_upper_alnum"] = this.fixtures[
-    "unique_alnum"
-  ].toUpperCase();
+  this.fixtures["unique_lower_alnum"] =
+    this.fixtures["unique_alnum"].toLowerCase();
+  this.fixtures["unique_upper_alnum"] =
+    this.fixtures["unique_alnum"].toUpperCase();
   this.fixtures["unique_hash"] = uniqueHash;
   this.fixtures["now"] = date;
   this.fixtures["uuid"] = generateUuid(now);
 
-  // make sure that we are not recording APM traces
-  if ((tracer as any)._tracer._url !== undefined) {
-    const url = (tracer as any)._tracer._url.href;
-    server.put(`${url}*`).passthrough();
+  if (server !== undefined) {
+    // make sure that we are not recording APM traces
+    if ((tracer as any)._tracer._url !== undefined) {
+      const url = (tracer as any)._tracer._url.href;
+      server.put(`${url}*`).passthrough();
+    }
+
+    // remove secrets from request headers before persisting
+    server.any().on("beforePersist", (_req: any, recording: any) => {
+      recording.request.headers =
+        recording.request.headers.filter(filterHeader);
+      recording.response.headers =
+        recording.response.headers.filter(filterHeader);
+
+      // remove timing information
+      delete recording.timings;
+    });
   }
-
-  // remove secrets from request headers before persisting
-  server.any().on("beforePersist", (req, recording) => {
-    recording.request.headers = recording.request.headers.filter(filterHeader);
-    recording.response.headers = recording.response.headers.filter(
-      filterHeader
-    );
-
-    // remove timing information
-    delete recording.timings;
-  });
 });
 
 // Disable PollyJS request interception when tests are in integration mode
 Before(async function (this: World) {
   if (this.polly?.mode == MODES.PASSTHROUGH) {
-    this.polly.configure({adapters: []})
+    this.polly.configure({ adapters: [] });
   }
 });
 
@@ -152,6 +181,10 @@ Before(async function (this: World) {
 // hence this.cleanup() must be defined after this.polly.stop().
 
 After(async function (this: World) {
+  if (testServerEnabled()) {
+    await stopTestServerSession(this);
+    return;
+  }
   if (this.polly !== undefined) {
     try {
       await this.polly.stop();
@@ -166,6 +199,9 @@ After(async function (this: World) {
 });
 
 AfterAll(function () {
+  if (testServerEnabled()) {
+    return;
+  }
   const recordMode = process.env.RECORD || "false";
   if (recordMode !== "false" || process.env.CLEANUP_CASSETTES !== "true") {
     return;
@@ -173,15 +209,16 @@ AfterAll(function () {
   const cassettesDir = path.resolve(__dirname, "../../cassettes");
 
   const getAllDirs = function (dirPath: string): string[] {
-    let files = fs.readdirSync(dirPath).map(file => path.join(dirPath, file));
+    let files = fs.readdirSync(dirPath).map((file) => path.join(dirPath, file));
     let arrayOfFiles: any = [];
 
     while (files.length > 0) {
-      const fileName = (files.pop() as string);
+      const fileName = files.pop() as string;
       if (fs.statSync(fileName).isDirectory()) {
-        const children = fs.readdirSync(fileName)
-          .map(file => path.join(fileName, file))
-          .filter(d => fs.statSync(d).isDirectory());
+        const children = fs
+          .readdirSync(fileName)
+          .map((file) => path.join(fileName, file))
+          .filter((d) => fs.statSync(d).isDirectory());
         if (children.length > 0) {
           files = files.concat(children);
         } else {
@@ -190,14 +227,16 @@ AfterAll(function () {
       }
     }
 
-    return arrayOfFiles
-  }
+    return arrayOfFiles;
+  };
 
   const existingCassettes = getAllDirs(cassettesDir);
   const usedCassettes = new Set(cassettes);
 
-  existingCassettes.filter(c => !usedCassettes.has(c)).forEach(cassette => {
-    console.log(`Removing unused cassette ${cassette}`);
-    fs.rmSync(cassette, { recursive: true });
-  });
+  existingCassettes
+    .filter((c) => !usedCassettes.has(c))
+    .forEach((cassette) => {
+      console.log(`Removing unused cassette ${cassette}`);
+      fs.rmSync(cassette, { recursive: true });
+    });
 });

--- a/features/support/world.ts
+++ b/features/support/world.ts
@@ -23,6 +23,9 @@ export class World {
   public fixtures: { [key: string]: any } = {};
   public opts: { [key: string]: any } = {};
   public pathParameters: { [key: string]: any } = {};
+  public testFeature = "";
+  public testScenario = "";
+  public testServerSession?: string;
 
   async cleanup() {
     const undo = this.undo;
@@ -37,7 +40,9 @@ export class World {
     if (RECORD_MODE === "false" || SLEEP_AFTER_REQUEST <= 0) {
       return Promise.resolve();
     }
-    return new Promise(resolve => setTimeout(resolve, SLEEP_AFTER_REQUEST * 1000));
+    return new Promise((resolve) =>
+      setTimeout(resolve, SLEEP_AFTER_REQUEST * 1000)
+    );
   }
 }
 

--- a/run-bdd-tests.sh
+++ b/run-bdd-tests.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 && pwd -P)"
+TEST_ARTIFACTS=${BDD_TEST_ARTIFACTS:-${REPO_ROOT}/features/generated}
+
+if [ ! -x "${TEST_ARTIFACTS}/test-server" ]; then
+    echo "Generated test server not found at ${TEST_ARTIFACTS}/test-server" >&2
+    exit 1
+fi
+if [ ! -f "${TEST_ARTIFACTS}/test-runner-data/manifest.json" ]; then
+    echo "Generated test runner manifest not found below ${TEST_ARTIFACTS}" >&2
+    exit 1
+fi
+
+TEST_SERVER_PID=""
+cleanup() {
+    if [ -n "${TEST_SERVER_PID}" ]; then
+        kill "${TEST_SERVER_PID}" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+TEST_SERVER_PORT=${BDD_TEST_SERVER_PORT:-18083}
+TEST_SERVER_LOG=${BDD_TEST_SERVER_LOG:-${TMPDIR:-/tmp}/datadog-typescript-test-server.log}
+"${TEST_ARTIFACTS}/test-server" --port "${TEST_SERVER_PORT}" >"${TEST_SERVER_LOG}" 2>&1 &
+TEST_SERVER_PID=$!
+for _ in {1..50}; do
+    if curl --silent --fail "http://127.0.0.1:${TEST_SERVER_PORT}/__openapi_transformer__/health" >/dev/null; then
+        break
+    fi
+    sleep 0.1
+done
+curl --silent --fail "http://127.0.0.1:${TEST_SERVER_PORT}/__openapi_transformer__/health" >/dev/null
+
+cd "${REPO_ROOT}"
+DD_TEST_SERVER_URL="http://127.0.0.1:${TEST_SERVER_PORT}" \
+DD_TEST_SITE_URL="127.0.0.1:${TEST_SERVER_PORT}" \
+DD_TEST_RUNNER_DATA="${TEST_ARTIFACTS}/test-runner-data" \
+RECORD=false \
+node bin/dd-cucumber-js "${TEST_ARTIFACTS}/test-runner-data/features" "$@"


### PR DESCRIPTION
## Summary

- load language-neutral request plans generated by openapi-transformer
- run the SDK Cucumber suite against the generated cassette replay server
- keep the native Cucumber assertions while removing native cassette ownership

## Testing

- generated all 169 feature files and 1,685 request plans
- ran the complete replay suite locally